### PR TITLE
Update tree-sitter grammar and queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 grammars
 *.wasm
 target

--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "julia"
 name = "Julia"
 description = "Julia support."
-version = "0.1.0"
+version = "0.1.1"
 schema_version = 1
 authors = ["Paul Berg <paul@plutojl.org>"]
 repository = "https://github.com/JuliaEditorSupport/zed-julia"

--- a/extension.toml
+++ b/extension.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/Pangoraw/zed-julia"
 
 [grammars.julia]
 repository = "https://github.com/tree-sitter/tree-sitter-julia"
-commit = "0a80d33aca49dd257625ab25ef3a506e2b99a554"
+commit = "acd5ca12cc278df7960629c2429a096c7ac4bbea"
 
 [language_servers.julia]
 languages = ["Julia"]

--- a/languages/julia/config.toml
+++ b/languages/julia/config.toml
@@ -1,16 +1,26 @@
 name = "Julia"
 grammar = "julia"
 path_suffixes = ["jl"]
+first_line_pattern = "^#!.*\\bjulia\\b"
 line_comments = ["# "]
-autoclose_before = ""
+autoclose_before = "}])"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
     { start = "(", end = ")", close = true, newline = true },
     { start = "\"", end = "\"", close = true, newline = false, not_in = [
         "comment",
         "string",
     ] },
     { start = "'", end = "'", close = true, newline = false, not_in = [
+        "comment",
+        "string",
+    ] },
+    { start = "`", end = "`", close = true, newline = false, not_in = [
+        "comment",
+        "string",
+    ] },
+    { start = "#=", end = " =#", close = true, newline = false, not_in = [
         "comment",
         "string",
     ] },

--- a/languages/julia/config.toml
+++ b/languages/julia/config.toml
@@ -26,3 +26,4 @@ brackets = [
     ] },
 ]
 collapsed_placeholder = "# ..."
+tab_size = 4

--- a/languages/julia/highlights.scm
+++ b/languages/julia/highlights.scm
@@ -41,47 +41,6 @@
 (macro_identifier
   (identifier) @function.macro) ; for any one using the variable highlight
 
-; Macro definitions
-(macro_definition
-  (signature
-    (call_expression
-      .
-      (identifier) @function.definition)))
-
-(macro_definition
-  (signature
-    (call_expression
-      (field_expression
-        (identifier) @function.definition .))))
-
-; Function definitions
-(function_definition
-  (signature
-    (call_expression
-      .
-      (identifier) @function.definition)))
-
-(function_definition
-  (signature
-    (call_expression
-      (field_expression
-        (identifier) @function.definition .))))
-
-; Short function definitions like foo(x) = 2x
-; See also the comment in outline.scm.
-(assignment
-  .
-  [
-    (call_expression . (identifier) @function.definition)
-    (typed_expression . (call_expression . (identifier) @function.definition))
-    (where_expression . (call_expression . (identifier) @function.definition))
-    (where_expression . (typed_expression . (call_expression . (identifier) @function.definition)))
-    (call_expression . (field_expression (identifier) @function.definition .))
-    (typed_expression . (call_expression . (field_expression (identifier) @function.definition .)))
-    (where_expression . (call_expression . (field_expression (identifier) @function.definition .)))
-    (where_expression . (typed_expression . (call_expression . (field_expression (identifier) @function.definition .))))
-  ])
-
 ; Builtins
 ((identifier) @function.builtin
   (#any-of? @function.builtin "_abstracttype" "_apply_iterate" "_apply_pure" "_call_in_world" "_call_in_world_total" "_call_latest" "_equiv_typedef" "_expr" "_primitivetype" "_setsuper!" "_structtype" "_typebody!" "_typevar" "applicable" "apply_type" "arrayref" "arrayset" "arraysize" "const_arrayref" "donotdelete" "fieldtype" "get_binding_type" "getfield" "ifelse" "invoke" "isa" "isdefined" "modifyfield!" "nfields" "replacefield!" "set_binding_type!" "setfield!" "sizeof" "svec" "swapfield!" "throw" "tuple" "typeassert" "typeof"))
@@ -544,8 +503,32 @@
     ")"
   ] @punctuation.special)
 
+; Match the dot in the @. macro
 (macro_identifier
-  (operator) @function.macro (#eq? @function.macro ".")) ; match the dot in the @. macro
+  (operator) @function.macro (#eq? @function.macro "."))
+
+; Macro and function definitions
+(signature
+  (call_expression
+    [
+      (identifier) @function.definition
+      (field_expression (identifier) @function.definition .)
+    ]))
+
+; Short function definitions like foo(x) = 2x
+(assignment
+  .
+  [
+    (call_expression (identifier) @function.definition)
+    (typed_expression . (call_expression (identifier) @function.definition))
+    (where_expression . (call_expression (identifier) @function.definition))
+    (where_expression . (typed_expression . (call_expression (identifier) @function.definition)))
+    (call_expression (field_expression (identifier) @function.definition .))
+    (typed_expression . (call_expression (field_expression (identifier) @function.definition .)))
+    (where_expression . (call_expression (field_expression (identifier) @function.definition .)))
+    (where_expression . (typed_expression . (call_expression (field_expression (identifier) @function.definition .))))
+  ]
+  (operator) @keyword.function)
 
 ; Literals
 (boolean_literal) @boolean

--- a/languages/julia/highlights.scm
+++ b/languages/julia/highlights.scm
@@ -68,17 +68,19 @@
         (identifier) @function.definition .))))
 
 ; Short function definitions like foo(x) = 2x
+; See also the comment in outline.scm.
 (assignment
   .
-  (call_expression
-    .
-    (identifier) @function.definition))
-
-(assignment
-  .
-  (call_expression
-    (field_expression
-      (identifier) @function.definition .)))
+  [
+    (call_expression . (identifier) @function.definition)
+    (typed_expression . (call_expression . (identifier) @function.definition))
+    (where_expression . (call_expression . (identifier) @function.definition))
+    (where_expression . (typed_expression . (call_expression . (identifier) @function.definition)))
+    (call_expression . (field_expression (identifier) @function.definition .))
+    (typed_expression . (call_expression . (field_expression (identifier) @function.definition .)))
+    (where_expression . (call_expression . (field_expression (identifier) @function.definition .)))
+    (where_expression . (typed_expression . (call_expression . (field_expression (identifier) @function.definition .))))
+  ])
 
 ; Builtins
 ((identifier) @function.builtin

--- a/languages/julia/highlights.scm
+++ b/languages/julia/highlights.scm
@@ -41,11 +41,44 @@
 (macro_identifier
   (identifier) @function.macro) ; for any one using the variable highlight
 
+; Macro definitions
 (macro_definition
   (signature
     (call_expression
       .
-      (identifier) @function.macro)))
+      (identifier) @function.definition)))
+
+(macro_definition
+  (signature
+    (call_expression
+      (field_expression
+        (identifier) @function.definition .))))
+
+; Function definitions
+(function_definition
+  (signature
+    (call_expression
+      .
+      (identifier) @function.definition)))
+
+(function_definition
+  (signature
+    (call_expression
+      (field_expression
+        (identifier) @function.definition .))))
+
+; Short function definitions like foo(x) = 2x
+(assignment
+  .
+  (call_expression
+    .
+    (identifier) @function.definition))
+
+(assignment
+  .
+  (call_expression
+    (field_expression
+      (identifier) @function.definition .)))
 
 ; Builtins
 ((identifier) @function.builtin
@@ -329,6 +362,7 @@
 
 ; Keywords
 [
+  "const"
   "global"
   "local"
 ] @keyword
@@ -399,6 +433,9 @@
 (for_clause
   "for" @keyword.repeat)
 
+(for_binding
+  "outer" @keyword.repeat)
+
 [
   (break_statement)
   (continue_statement)
@@ -428,6 +465,7 @@
 
 (struct_definition
   [
+    "mutable"
     "struct"
     "end"
   ] @keyword)
@@ -452,11 +490,6 @@
 
 (return_statement
   "return" @keyword.return)
-
-[
-  "const"
-  "mutable"
-] @type.qualifier
 
 ; Operators & Punctuation
 [
@@ -502,6 +535,16 @@
   "}"
 ] @punctuation.bracket
 
+(string_interpolation
+  [
+    "$"
+    "("
+    ")"
+  ] @punctuation.special)
+
+(macro_identifier
+  (operator) @function.macro (#eq? @function.macro ".")) ; match the dot in the @. macro
+
 ; Literals
 (boolean_literal) @boolean
 
@@ -515,9 +558,9 @@
 ((identifier) @constant.builtin
   (#any-of? @constant.builtin "nothing" "missing"))
 
-(character_literal) @character
+(character_literal) @string
 
-(escape_sequence) @escape
+(escape_sequence) @string.escape
 
 (string_literal) @string
 
@@ -538,6 +581,8 @@
     (function_definition)
     (assignment)
     (const_statement)
+    (open_tuple
+      (identifier))
   ])
 
 [

--- a/languages/julia/highlights.scm
+++ b/languages/julia/highlights.scm
@@ -574,7 +574,7 @@
 (prefixed_command_literal
   prefix: (identifier) @function.macro) @string.special
 
-((string_literal) @string.doc
+((string_literal) @comment.doc
   .
   [
     (module_definition)

--- a/languages/julia/injections.scm
+++ b/languages/julia/injections.scm
@@ -1,4 +1,5 @@
 ; Inject markdown in docstrings
+; Be aware that this will clutter the outline view with markdown headers.
 ((string_literal) @content
   .
   [
@@ -8,8 +9,10 @@
     (function_definition)
     (assignment)
     (const_statement)
+    (open_tuple
+      (identifier))
   ]
-  (#lua-match? @content "^\"\"\"")
+  (#match? @content "^\"\"\"")
   (#set! "language" "markdown")
   (#offset! @content 0 3 0 -3))
 

--- a/languages/julia/injections.scm
+++ b/languages/julia/injections.scm
@@ -13,8 +13,7 @@
       (identifier))
   ]
   (#match? @content "^\"\"\"")
-  (#set! "language" "markdown")
-  (#offset! @content 0 3 0 -3))
+  (#set! "language" "markdown"))
 
 ([
   (line_comment)
@@ -25,5 +24,4 @@
 ((prefixed_string_literal
   prefix: (identifier) @_prefix) @content
   (#eq? @_prefix "r")
-  (#set! "language" "regex")
-  (#offset! @content 0 2 0 -1))
+  (#set! "language" "regex"))

--- a/languages/julia/outline.scm
+++ b/languages/julia/outline.scm
@@ -36,20 +36,19 @@
 ; Match short function definitions like foo(x) = 2x.
 ; These don't have signatures so, we need to match eight different nested combinations
 ; of call_expressions with return types and/or where clauses.
-; TODO: there may be an elegant way to handle nested combinations.
 (assignment
   .
   [
     ; match `foo()` or `foo()::T` or `foo() where...` or `foo()::T where...`
-    (call_expression . (identifier) @name (argument_list) @context)
-    (typed_expression . (call_expression . (identifier) @name (argument_list) @context) "::" @context (_) @context)
-    (where_expression . (call_expression . (identifier) @name (argument_list) @context) "where" @context (_) @context)
-    (where_expression . (typed_expression . (call_expression . (identifier) @name (argument_list) @context) "::" @context (_) @context) "where" @context (_) @context)
+    (call_expression (identifier) @name (argument_list) @context)
+    (typed_expression . (call_expression (identifier) @name (argument_list) @context) _+ @context)
+    (where_expression . (call_expression (identifier) @name (argument_list) @context) _+ @context)
+    (where_expression . (typed_expression . (call_expression (identifier) @name (argument_list) @context) _+ @context) _+ @context)
     ; match `Base.foo()` or `Base.foo()::T` or `Base.foo() where...` or `Base.foo()::T where...`
-    (call_expression . (field_expression _+ @context (identifier) @name .) (argument_list) @context)
-    (typed_expression . (call_expression . (field_expression _+ @context (identifier) @name .) (argument_list) @context) "::" @context (_) @context)
-    (where_expression . (call_expression . (field_expression _+ @context (identifier) @name .) (argument_list) @context) "where" @context (_) @context)
-    (where_expression . (typed_expression . (call_expression . (field_expression _+ @context (identifier) @name .) (argument_list) @context) "::" @context (_) @context) "where" @context (_) @context)
+    (call_expression (field_expression _+ @context (identifier) @name .) (argument_list) @context)
+    (typed_expression . (call_expression (field_expression _+ @context (identifier) @name .) (argument_list) @context) _+ @context)
+    (where_expression . (call_expression (field_expression _+ @context (identifier) @name .) (argument_list) @context) _+ @context)
+    (where_expression . (typed_expression . (call_expression (field_expression _+ @context (identifier) @name .) (argument_list) @context) _+ @context) _+ @context)
   ]) @item
 
 (macro_definition

--- a/languages/julia/outline.scm
+++ b/languages/julia/outline.scm
@@ -23,34 +23,46 @@
 
 (function_definition
   "function" @context
-  (signature [
-    (identifier) @name
-    (typed_expression
-      (call_expression (_) @name (argument_list) @context) "::" @context (_) @context)
-    (call_expression (_) @name (argument_list) @context)
-  ]
-    (unary_typed_expression)? @context
-  )
-  (type_parameter_list)? @context
-  (where_clause)? @context) @item
+  (signature
+    (call_expression
+      [
+        (identifier) @name ; match foo()
+        (field_expression _+ @context (identifier) @name .) ; match Base.foo()
+      ]
+      (argument_list)? @context)
+    (_)* @context ; match the rest of the signature e.g., return_type and/or where_clause
+  )) @item
 
+; Match short function definitions like foo(x) = 2x.
+; These don't have signatures so, we need to match eight different nested combinations
+; of call_expressions with return types and/or where clauses.
+; TODO: there may be an elegant way to handle nested combinations.
 (assignment
+  .
   [
-   (call_expression (_) @name (argument_list) @context)
-   (where_expression (call_expression (_) @name (argument_list) @context) "where" @context (_) @context)
-   (typed_expression
-     (call_expression (_) @name (argument_list) @context) "::" @context (_) @context)
+    ; match `foo()` or `foo()::T` or `foo() where...` or `foo()::T where...`
+    (call_expression . (identifier) @name (argument_list) @context)
+    (typed_expression . (call_expression . (identifier) @name (argument_list) @context) "::" @context (_) @context)
+    (where_expression . (call_expression . (identifier) @name (argument_list) @context) "where" @context (_) @context)
+    (where_expression . (typed_expression . (call_expression . (identifier) @name (argument_list) @context) "::" @context (_) @context) "where" @context (_) @context)
+    ; match `Base.foo()` or `Base.foo()::T` or `Base.foo() where...` or `Base.foo()::T where...`
+    (call_expression . (field_expression _+ @context (identifier) @name .) (argument_list) @context)
+    (typed_expression . (call_expression . (field_expression _+ @context (identifier) @name .) (argument_list) @context) "::" @context (_) @context)
+    (where_expression . (call_expression . (field_expression _+ @context (identifier) @name .) (argument_list) @context) "where" @context (_) @context)
+    (where_expression . (typed_expression . (call_expression . (field_expression _+ @context (identifier) @name .) (argument_list) @context) "::" @context (_) @context) "where" @context (_) @context)
   ]) @item
 
 (macro_definition
   "macro" @context
-  (signature [
-    (identifier) @name
-    (typed_expression
-      (call_expression (_) @name (argument_list) @context) "::" @context (_) @context)
-    (call_expression (_) @name (argument_list) @context)
-  ])
-  ) @item
+  (signature
+    (call_expression
+      [
+        (identifier) @name ; match foo()
+        (field_expression _+ @context (identifier) @name .) ; match Base.foo()
+      ]
+      (argument_list)? @context)
+    (_)* @context ; match the rest of the signature e.g., return_type
+  )) @item
 
 (struct_definition
   "mutable"? @context


### PR DESCRIPTION
Thank you @Pangoraw for getting this repo off the ground!

There was a minor upgrade to the grammar and I have changed the commit in `extension.toml` accordingly.

The rest of this PR deals with the scheme and toml files in `language/julia/`. The commit messages should be comprehensive. I tested the changes locally. Let me know if I should make further changes.

I'm wondering if we should keep the following lines but I haven't touched them as they seem to do no harm:
1. **config.toml**: Is `collapsed_placeholder = "# ..."` copied over from another language?
2. **injections.scm**: AFAIK, `#offset!` is only used by nvim. Zed seems to ignore that. 