### PR TITLE
Highlighting for New FieldError Exception in julia 1.12

### DIFF
--- a/languages/julia/highlights.scm
+++ b/languages/julia/highlights.scm
@@ -189,6 +189,7 @@
     "Exception"
     "ExponentialBackOff"
     "Expr"
+    "FieldError"
     "Float16"
     "Float32"
     "Float64"


### PR DESCRIPTION
commit https://github.com/JuliaLang/julia/commit/7e5d9a3b4603907ce63660bb09d243cf4ece3609 adds `FieldError` exception.