### PR TITLE
Documentation for installation & improve error message when julia binary not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 This extension adds support for the [Julia](https://julialang.org/) language in
 the [zed](https://zed.dev) editor.
 
-## Getting started
 
 ### Installing Julia / Zed / Zed Julia extension
 1. Install Julia for your platform: https://julialang.org/downloads/

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ the [zed](https://zed.dev) editor.
 ### Installing Julia / Zed / Zed Julia extension
 1. Install Julia for your platform: https://julialang.org/downloads/
 2. Install Zed for your platform: https://zed.dev/download
-    At the end of this step you should be able to start Zed.
 3. Start Zed.
 4. Inside Zed, go to the extensions view by
 executing the ``zed: extensions`` command (click Zed->Extensions).

--- a/README.md
+++ b/README.md
@@ -2,3 +2,17 @@
 
 This extension adds support for the [Julia](https://julialang.org/) language in
 the [zed](https://zed.dev) editor.
+
+## Getting started
+
+### Installing Julia / Zed / Zed Julia extension
+1. Install Julia for your platform: https://julialang.org/downloads/
+2. Install Zed for your platform: https://zed.dev/download
+    At the end of this step you should be able to start Zed.
+3. Start Zed.
+4. Inside Zed, go to the extensions view by
+executing the ``zed: extensions`` command (click Zed->Extensions).
+5. In the extensions view, simply search for the term ``julia`` in the search box, then select the extension named ``Julia`` and click the install button. You might have to restart Zed after this step.
+
+The Julia Zed extension looks for your Julia binary in the standard locations.
+Make sure that the Julia binary is on your ``PATH``.

--- a/src/julia.rs
+++ b/src/julia.rs
@@ -14,7 +14,7 @@ impl zed::Extension for JuliaExtension {
         worktree: &zed::Worktree,
     ) -> Result<zed::Command> {
         let Some(julia_bin) = worktree.which("julia") else {
-            return Err("julia not available".to_string());
+            return Err("Unable to find julia binary. Make sure the PATH variable contains the directory where the julia binary is located.".to_string());
         };
         Ok(zed::Command {
             command: julia_bin.to_string(),


### PR DESCRIPTION
closing #7 

The new text in the README is adapted from the julia-vscode extension README.
https://github.com/julia-vscode/julia-vscode