### PR TITLE
Recognize `begin` and `end` as keywords when used in array indices

### DIFF
--- a/languages/julia/highlights.scm
+++ b/languages/julia/highlights.scm
@@ -575,3 +575,8 @@
   (line_comment)
   (block_comment)
 ] @comment
+
+(index_expression
+  (vector_expression
+    (identifier) @keyword)
+  (#any-of? @keyword "begin" "end"))

--- a/languages/julia/highlights.scm
+++ b/languages/julia/highlights.scm
@@ -581,6 +581,8 @@
     (identifier) @keyword)
   (#any-of? @keyword "begin" "end"))
 
-(range_expression
-  (identifier) @keyword
+(index_expression
+  (vector_expression
+    (range_expression
+      (identifier) @keyword))
   (#any-of? @keyword "begin" "end"))

--- a/languages/julia/highlights.scm
+++ b/languages/julia/highlights.scm
@@ -580,3 +580,7 @@
   (vector_expression
     (identifier) @keyword)
   (#any-of? @keyword "begin" "end"))
+
+(range_expression
+  (identifier) @keyword
+  (#any-of? @keyword "begin" "end"))


### PR DESCRIPTION
A lot of text editors recognize `begin` and `end` in array indices as keywords.
Granted, they probably do this because they are stupid and just highlight based on regex, but given that `begin` and `end` are special when used as array indices I think it makes sense to highlight them.

It might be sensible to highlight them as something else though, to distinguish them from their counterparts when used outside array indices. I'm open to suggestions.