### PR TITLE
Docstrings on annotated definitions + on strings stolen by preceding top level macros

### DIFF
--- a/languages/julia/highlights.scm
+++ b/languages/julia/highlights.scm
@@ -581,6 +581,7 @@
   .
   [
     (identifier)
+    (macrocall_expression)
     (open_tuple
       (identifier))
   ])
@@ -590,6 +591,43 @@
   .
   [
     (identifier)
+    (macrocall_expression)
+    (open_tuple
+      (identifier))
+  ])
+
+(module_definition
+  (macrocall_expression
+    (macro_argument_list
+      (string_literal) @comment.doc .))
+  .
+  [
+    (identifier)
+    (macrocall_expression)
+    (module_definition)
+    (abstract_definition)
+    (struct_definition)
+    (function_definition)
+    (assignment)
+    (const_statement)
+    (open_tuple
+      (identifier))
+  ])
+
+(source_file
+  (macrocall_expression
+    (macro_argument_list
+      (string_literal) @comment.doc .))
+  .
+  [
+    (identifier)
+    (macrocall_expression)
+    (module_definition)
+    (abstract_definition)
+    (struct_definition)
+    (function_definition)
+    (assignment)
+    (const_statement)
     (open_tuple
       (identifier))
   ])

--- a/languages/julia/highlights.scm
+++ b/languages/julia/highlights.scm
@@ -599,6 +599,7 @@
 (module_definition
   (macrocall_expression
     (macro_argument_list
+      (_)+
       (string_literal) @comment.doc .))
   .
   [
@@ -617,6 +618,7 @@
 (source_file
   (macrocall_expression
     (macro_argument_list
+      (_)+
       (string_literal) @comment.doc .))
   .
   [

--- a/languages/julia/highlights.scm
+++ b/languages/julia/highlights.scm
@@ -565,6 +565,7 @@
     (abstract_definition)
     (struct_definition)
     (function_definition)
+    (macro_definition)
     (assignment)
     (const_statement)
   ])

--- a/languages/julia/highlights.scm
+++ b/languages/julia/highlights.scm
@@ -430,7 +430,7 @@
       (identifier))
   ])
 
-(module_definition
+((module_definition
   (macrocall_expression
     (macro_argument_list
       (_)+
@@ -448,8 +448,9 @@
     (open_tuple
       (identifier))
   ])
+  (#match? @comment.doc "^\"\"\""))
 
-(source_file
+((source_file
   (macrocall_expression
     (macro_argument_list
       (_)+
@@ -467,6 +468,7 @@
     (open_tuple
       (identifier))
   ])
+  (#match? @comment.doc "^\"\"\""))
 
 [
   (line_comment)

--- a/languages/julia/highlights.scm
+++ b/languages/julia/highlights.scm
@@ -386,8 +386,8 @@
 (prefixed_command_literal
   prefix: (identifier) @function.macro) @string.special
 
-; TODO
-; Docstrings
+; doc macro docstrings:
+; @doc "..." x
 ((macrocall_expression
   (macro_identifier "@" (identifier)) @function.macro
   (macro_argument_list
@@ -395,67 +395,63 @@
     (string_literal) @comment.doc))
   (#eq? @function.macro "@doc"))
 
-; TODO continued
+; docstrings preceding documentable elements at the top of a source file:
 (source_file
-  (string_literal) @comment.doc
-  .
+  ; The Docstring:
   [
+    (string_literal) @comment.doc
+    ; Workaroud: Find strings stolen as the last argument to a preceding macro
+    ; https://github.com/tree-sitter/tree-sitter-julia/issues/150
+    (macrocall_expression
+      (macro_argument_list
+      (_)+
+      (string_literal) @comment.doc .))
+  ]
+  .
+  ; The documentable element:
+  [
+    (assignment)
+    (const_statement)
+    (global_statement)
+    (abstract_definition)
+    (function_definition)
+    (macro_definition)
+    (module_definition)
+    (struct_definition)
+    (macrocall_expression) ; Covers things like @kwdef struct X ... end
     (identifier)
-    (macrocall_expression)
     (open_tuple
       (identifier))
   ])
 
-; TODO continued
+; docstrings preceding documentable elements at the top of a module:
 (module_definition
-  (string_literal) @comment.doc
-  .
+  ; The Docstring:
   [
-    (identifier)
-    (macrocall_expression)
-    (open_tuple
-      (identifier))
-  ])
-
-((module_definition
-  (macrocall_expression
-    (macro_argument_list
+    (string_literal) @comment.doc
+    ; Workaroud: Find strings stolen as the last argument to a preceding macro
+    ; https://github.com/tree-sitter/tree-sitter-julia/issues/150
+    (macrocall_expression
+      (macro_argument_list
       (_)+
       (string_literal) @comment.doc .))
+  ]
   .
+  ; The documentable element:
   [
-    (identifier)
-    (macrocall_expression)
-    (module_definition)
-    (abstract_definition)
-    (struct_definition)
-    (function_definition)
     (assignment)
     (const_statement)
+    (global_statement)
+    (abstract_definition)
+    (function_definition)
+    (macro_definition)
+    (module_definition)
+    (struct_definition)
+    (macrocall_expression) ; Covers things like @kwdef struct X ... end
+    (identifier)
     (open_tuple
       (identifier))
   ])
-  (#match? @comment.doc "^\"\"\""))
-
-((source_file
-  (macrocall_expression
-    (macro_argument_list
-      (_)+
-      (string_literal) @comment.doc .))
-  .
-  [
-    (identifier)
-    (macrocall_expression)
-    (module_definition)
-    (abstract_definition)
-    (struct_definition)
-    (function_definition)
-    (assignment)
-    (const_statement)
-    (open_tuple
-      (identifier))
-  ])
-  (#match? @comment.doc "^\"\"\""))
 
 [
   (line_comment)

--- a/languages/julia/highlights.scm
+++ b/languages/julia/highlights.scm
@@ -396,7 +396,7 @@
   (#eq? @function.macro "@doc"))
 
 ; docstrings preceding documentable elements at the top of a source file:
-(source_file
+((source_file
   ; The Docstring:
   [
     (string_literal) @comment.doc
@@ -423,9 +423,10 @@
     (open_tuple
       (identifier))
   ])
+  (#match? @comment.doc "^\"\"\""))
 
 ; docstrings preceding documentable elements at the top of a module:
-(module_definition
+((module_definition
   ; The Docstring:
   [
     (string_literal) @comment.doc
@@ -452,6 +453,7 @@
     (open_tuple
       (identifier))
   ])
+  (#match? @comment.doc "^\"\"\""))
 
 [
   (line_comment)

--- a/languages/julia/highlights.scm
+++ b/languages/julia/highlights.scm
@@ -386,19 +386,6 @@
 (prefixed_command_literal
   prefix: (identifier) @function.macro) @string.special
 
-; TODO: Substitute NVIM's @string.documentation with Zed's @comment.doc
-((string_literal) @comment.doc
-  .
-  [
-    (abstract_definition)
-    (assignment)
-    (const_statement)
-    (function_definition)
-    (macro_definition)
-    (module_definition)
-    (struct_definition)
-  ])
-
 ; TODO
 ; Docstrings
 ((macrocall_expression

--- a/languages/julia/injections.scm
+++ b/languages/julia/injections.scm
@@ -1,18 +1,3 @@
-; Inject markdown in docstrings
-; Be aware that this will clutter the outline view with markdown headers.
-((string_literal) @content
-  .
-  [
-    (abstract_definition)
-    (assignment)
-    (const_statement)
-    (function_definition)
-    (macro_definition)
-    (module_definition)
-    (struct_definition)
-  ]
-  (#set! "language" "markdown"))
-
 ((macrocall_expression
   (macro_identifier "@" (identifier)) @function.macro
   (macro_argument_list

--- a/languages/julia/injections.scm
+++ b/languages/julia/injections.scm
@@ -1,3 +1,5 @@
+; doc macro docstrings:
+; @doc "..." x
 ((macrocall_expression
   (macro_identifier "@" (identifier)) @function.macro
   (macro_argument_list
@@ -6,25 +8,34 @@
   (#eq? @function.macro "@doc")
   (#set! "language" "markdown"))
 
+
+; docstrings preceding documentable elements at the top of a source file:
 ((source_file
-  (string_literal) @content
-  .
+  ; The Docstring:
   [
+    (string_literal) @content
+    ; Workaroud: Find strings stolen as the last argument to a preceding macro
+    ; https://github.com/tree-sitter/tree-sitter-julia/issues/150
+    (macrocall_expression
+      (macro_argument_list
+      (_)+
+      (string_literal) @content .))
+  ]
+  .
+  ; The documentable element:
+  [
+    (assignment)
+    (const_statement)
+    (global_statement)
+    (abstract_definition)
+    (function_definition)
+    (macro_definition)
+    (module_definition)
+    (struct_definition)
+    (macrocall_expression) ; Covers things like @kwdef struct X ... end
     (identifier)
-    (macrocall_expression)
     (open_tuple
       (identifier))
-  ])
-  (#set! "language" "markdown"))
-
-((module_definition
-  (string_literal) @content
-  .
-  [
-      (identifier)
-      (macrocall_expression)
-      (open_tuple
-        (identifier))
   ])
   (#set! "language" "markdown"))
 
@@ -49,32 +60,14 @@
   (#match? @content "^\"\"\"")
   (#set! "language" "markdown"))
 
-((source_file
-  (macrocall_expression
-    (macro_argument_list
-      (_)+
-      (string_literal) @content .))
-  .
-  [
-    (identifier)
-    (macrocall_expression)
-    (module_definition)
-    (abstract_definition)
-    (struct_definition)
-    (function_definition)
-    (assignment)
-    (const_statement)
-    (open_tuple
-      (identifier))
-  ])
-  (#match? @content "^\"\"\"")
-  (#set! "language" "markdown"))
 
+; Regex Language Injection
 ((prefixed_string_literal
   prefix: (identifier) @_prefix) @content
   (#eq? @_prefix "r")
   (#set! "language" "regex"))
 
+; SQL Language Injection
 ((prefixed_command_literal
   prefix: (identifier) @_prefix) @content
   (#eq? @_prefix "sql")

--- a/languages/julia/injections.scm
+++ b/languages/julia/injections.scm
@@ -46,6 +46,7 @@
 ((module_definition
   (macrocall_expression
     (macro_argument_list
+      (_)+
       (string_literal) @content .))
   .
   [
@@ -65,6 +66,7 @@
 ((source_file
   (macrocall_expression
     (macro_argument_list
+      (_)+
       (string_literal) @content .))
   .
   [

--- a/languages/julia/injections.scm
+++ b/languages/julia/injections.scm
@@ -62,6 +62,7 @@
     (open_tuple
       (identifier))
   ])
+  (#match? @content "^\"\"\"")
   (#set! "language" "markdown"))
 
 ((source_file
@@ -82,6 +83,7 @@
     (open_tuple
       (identifier))
   ])
+  (#match? @content "^\"\"\"")
   (#set! "language" "markdown"))
 
 ((prefixed_string_literal

--- a/languages/julia/injections.scm
+++ b/languages/julia/injections.scm
@@ -1,11 +1,11 @@
 ; doc macro docstrings:
 ; @doc "..." x
 ((macrocall_expression
-  (macro_identifier "@" (identifier)) @function.macro
+  (macro_identifier "@" (identifier)) @_macro
   (macro_argument_list
     .
     (string_literal) @content))
-  (#eq? @function.macro "@doc")
+  (#eq? @_macro "@doc")
   (#set! "language" "markdown"))
 
 

--- a/languages/julia/injections.scm
+++ b/languages/julia/injections.scm
@@ -7,6 +7,7 @@
     (abstract_definition)
     (struct_definition)
     (function_definition)
+    (macro_definition)
     (assignment)
     (const_statement)
   ]

--- a/languages/julia/injections.scm
+++ b/languages/julia/injections.scm
@@ -26,6 +26,7 @@
   .
   [
     (identifier)
+    (macrocall_expression)
     (open_tuple
       (identifier))
   ])
@@ -36,16 +37,49 @@
   .
   [
       (identifier)
+      (macrocall_expression)
       (open_tuple
         (identifier))
   ])
   (#set! "language" "markdown"))
 
-([
-  (line_comment)
-  (block_comment)
-] @injection.content
-  (#set! "language" "comment"))
+((module_definition
+  (macrocall_expression
+    (macro_argument_list
+      (string_literal) @content .))
+  .
+  [
+    (identifier)
+    (macrocall_expression)
+    (module_definition)
+    (abstract_definition)
+    (struct_definition)
+    (function_definition)
+    (assignment)
+    (const_statement)
+    (open_tuple
+      (identifier))
+  ])
+  (#set! "language" "markdown"))
+
+((source_file
+  (macrocall_expression
+    (macro_argument_list
+      (string_literal) @content .))
+  .
+  [
+    (identifier)
+    (macrocall_expression)
+    (module_definition)
+    (abstract_definition)
+    (struct_definition)
+    (function_definition)
+    (assignment)
+    (const_statement)
+    (open_tuple
+      (identifier))
+  ])
+  (#set! "language" "markdown"))
 
 ((prefixed_string_literal
   prefix: (identifier) @_prefix) @content

--- a/languages/julia/injections.scm
+++ b/languages/julia/injections.scm
@@ -11,7 +11,6 @@
     (module_definition)
     (struct_definition)
   ]
-  (#match? @content "^\"\"\"")
   (#set! "language" "markdown"))
 
 ((macrocall_expression

--- a/languages/julia/injections.scm
+++ b/languages/julia/injections.scm
@@ -37,29 +37,39 @@
     (open_tuple
       (identifier))
   ])
+  (#match? @content "^\"\"\"")
   (#set! "language" "markdown"))
 
+; docstrings preceding documentable elements at the top of a module:
 ((module_definition
-  (macrocall_expression
-    (macro_argument_list
+  ; The Docstring:
+  [
+    (string_literal) @content
+    ; Workaroud: Find strings stolen as the last argument to a preceding macro
+    ; https://github.com/tree-sitter/tree-sitter-julia/issues/150
+    (macrocall_expression
+      (macro_argument_list
       (_)+
       (string_literal) @content .))
+  ]
   .
+  ; The documentable element:
   [
-    (identifier)
-    (macrocall_expression)
-    (module_definition)
-    (abstract_definition)
-    (struct_definition)
-    (function_definition)
     (assignment)
     (const_statement)
+    (global_statement)
+    (abstract_definition)
+    (function_definition)
+    (macro_definition)
+    (module_definition)
+    (struct_definition)
+    (macrocall_expression) ; Covers things like @kwdef struct X ... end
+    (identifier)
     (open_tuple
       (identifier))
   ])
   (#match? @content "^\"\"\"")
   (#set! "language" "markdown"))
-
 
 ; Regex Language Injection
 ((prefixed_string_literal

--- a/syntax-test-cases/docstrings.jl
+++ b/syntax-test-cases/docstrings.jl
@@ -54,22 +54,6 @@ This _should_ have `markdown` injected!
 x
 end
 
-begin
-  # (identifier)
-  """
-  This _should_ have `markdown` injected!
-  """
-  x
-end
-
-let
-  # (identifier)
-  """
-  This _should_ have `markdown` injected!
-  """
-  x
-end
-
 # (call_expression)
 foobar("This should _not_ have `markdown` injected!", x)
 

--- a/syntax-test-cases/docstrings.jl
+++ b/syntax-test-cases/docstrings.jl
@@ -88,14 +88,12 @@ struct A end
 @info "This should _not_ have `markdown` injected!"
 struct A end
 
-# This means that as of now, we are highlighting this setup _incorrectly_!
+# We also don't highlight single-quoted strings as docstrings in this setup,
+# because docstrings are generally triple-quoted.
+# In other words, this is still highlighted correctly:
 @foobar x "This should _not_ have `markdown` injected!"
 struct A end
 
-# But this setup (which is more common) is not broken.
-@info "This should _not_ have `markdown` injected!" x
-struct A end
-
-# However, this setup is possibly not that rare, and sadly broken.
-@info "Yo" "This should _not_ have `markdown` injected!"
+# However, this rare setup is currently highlighted incorrectly.
+@info "Yo" """This should _not_ have `markdown` injected!"""
 struct A end

--- a/syntax-test-cases/docstrings.jl
+++ b/syntax-test-cases/docstrings.jl
@@ -97,3 +97,7 @@ struct A end
 # However, this rare setup is currently highlighted incorrectly.
 @info "Yo" """This should _not_ have `markdown` injected!"""
 struct A end
+
+# Only the docstrings stolen by macros have this restriction applied, so
+# for example the following still works:
+@doc "This _should_ have `markdown` injected!" foobar

--- a/syntax-test-cases/docstrings.jl
+++ b/syntax-test-cases/docstrings.jl
@@ -95,3 +95,7 @@ This _should_ have `markdown` injected!
 This _should_ have `markdown` injected!
 """
 struct A end
+
+@info "This should _not_ have `markdown` injected!"
+
+struct A end

--- a/syntax-test-cases/docstrings.jl
+++ b/syntax-test-cases/docstrings.jl
@@ -94,10 +94,24 @@ struct A end
 @foobar x "This should _not_ have `markdown` injected!"
 struct A end
 
-# However, this rare setup is currently highlighted incorrectly.
+# However, this rare setup is currently highlighted INCORRECTLY.
 @info "Yo" """This should _not_ have `markdown` injected!"""
 struct A end
 
 # Only the docstrings stolen by macros have this restriction applied, so
 # for example the following still works:
 @doc "This _should_ have `markdown` injected!" foobar
+
+# And the following also works, if the docstring is not stolen:
+"This _should_ have `markdown` injected!"
+function foobar end
+
+"This _should_ have `markdown` injected!"
+foobar
+
+# However, if a single-quoted docstring is stolen, it is currently
+# highlighted INCORRECTLY:
+@info "Yo"
+
+"This _should_ have `markdown` injected!"
+foobar

--- a/syntax-test-cases/docstrings.jl
+++ b/syntax-test-cases/docstrings.jl
@@ -109,7 +109,7 @@ struct A end
 struct A end
 
 # But this setup (which is more common) is not broken.
-@foobar "This should _not_ have `markdown` injected!" x
+@info "This should _not_ have `markdown` injected!" x
 struct A end
 
 # However, this setup is possibly not that rare, and sadly broken.

--- a/syntax-test-cases/docstrings.jl
+++ b/syntax-test-cases/docstrings.jl
@@ -55,20 +55,43 @@ x
 end
 
 begin
-# (identifier)
-"""
-This _should_ have `markdown` injected!
-"""
-x
+  # (identifier)
+  """
+  This _should_ have `markdown` injected!
+  """
+  x
 end
 
 let
-# (identifier)
-"""
-This _should_ have `markdown` injected!
-"""
-x
+  # (identifier)
+  """
+  This _should_ have `markdown` injected!
+  """
+  x
 end
 
 # (call_expression)
 foobar("This should _not_ have `markdown` injected!", x)
+
+
+"""
+This _should_ have `markdown` injected!
+"""
+@cxxdereference function f()
+
+end
+
+"""
+This _should_ have `markdown` injected!
+"""
+@kwdef struct A end
+
+# BUG: As of Sep. 2024, top level macro calls will steal literals!
+# The string following this macro call is parsed as an argument to it.
+# https://github.com/JuliaEditorSupport/zed-julia/issues/15
+@qmlfunction foobar
+
+"""
+This _should_ have `markdown` injected!
+"""
+struct A end

--- a/syntax-test-cases/docstrings.jl
+++ b/syntax-test-cases/docstrings.jl
@@ -95,7 +95,19 @@ This _should_ have `markdown` injected!
 This _should_ have `markdown` injected!
 """
 struct A end
+# We highlight it (correctly) by querying for strings in macrocalls
+# where a valid target for docstrings immediately follow the macrocall.
 
+# BUT!
+# We don't highlight strings in macrocalls if they are the only argument,
+# because this setup is quite common:
 @info "This should _not_ have `markdown` injected!"
+struct A end
 
+# This means that as of now, we are highlighting this setup _incorrectly_!
+@foobar x "This should _not_ have `markdown` injected!"
+struct A end
+
+# But this setup (which is more common) is not broken.
+@foobar "This should _not_ have `markdown` injected!" x
 struct A end

--- a/syntax-test-cases/docstrings.jl
+++ b/syntax-test-cases/docstrings.jl
@@ -84,34 +84,37 @@ struct A end
 
 # BUT!
 # We don't highlight strings in macrocalls if they are the only argument,
-# because this setup is quite common:
-@info "This should _not_ have `markdown` injected!"
+# because this setup is quite plausible:
+@info """
+This should _not_ have `markdown` injected!
+"""
+
 struct A end
 
 # We also don't highlight single-quoted strings as docstrings in this setup,
-# because docstrings are generally triple-quoted.
+# because docstrings are _usually_ triple-quoted.
 # In other words, this is still highlighted correctly:
 @foobar x "This should _not_ have `markdown` injected!"
+
 struct A end
 
 # However, this rare setup is currently highlighted INCORRECTLY.
-@info "Yo" """This should _not_ have `markdown` injected!"""
+@foobar "Yo" """This should _not_ have `markdown` injected!"""
+
 struct A end
 
 # Only the docstrings stolen by macros have this restriction applied, so
-# for example the following still works:
+# for example the following still works: (using the @doc macro)
 @doc "This _should_ have `markdown` injected!" foobar
 
-# And the following also works, if the docstring is not stolen:
+# After cleaning up the queries, the single-quote restriction also applies
+# to top level docstrings preceding documentable items. The following is
+# highlighed INCORRECTLY:
 "This _should_ have `markdown` injected!"
 function foobar end
 
+# As is this:
+module X
 "This _should_ have `markdown` injected!"
 foobar
-
-# However, if a single-quoted docstring is stolen, it is currently
-# highlighted INCORRECTLY:
-@info "Yo"
-
-"This _should_ have `markdown` injected!"
-foobar
+end

--- a/syntax-test-cases/docstrings.jl
+++ b/syntax-test-cases/docstrings.jl
@@ -111,3 +111,7 @@ struct A end
 # But this setup (which is more common) is not broken.
 @foobar "This should _not_ have `markdown` injected!" x
 struct A end
+
+# However, this setup is possibly not that rare, and sadly broken.
+@info "Yo" "This should _not_ have `markdown` injected!"
+struct A end


### PR DESCRIPTION
NOTE: This is absolutely horrendous! It is at least a solution to https://github.com/JuliaEditorSupport/zed-julia/issues/15#issue-2502596294 as promised, but I'm more than happy to leave this out for now and implement it in a cleaner way if/when we can get the grammar fixed.

The following cases were broken before, but are now highlighted correctly:

<img src="https://github.com/user-attachments/assets/bd1f1f3f-45e2-49d1-a753-dff7aa8d17a9" width=500>

Essentially, the problem is that the docstrings are incorrectly parsed as arguments to the preceding macro. The workaround is querying for items which can have docstrings and are immediately following a macro call which has a string as its last argument, but not as its only argument. This very specific query avoids incorrectly highlighting strings in common macros like this:

<img src="https://github.com/user-attachments/assets/2847deb2-8a3f-432e-81cb-d5194622ca0f" width=500>