### PR TITLE
Update to tree-sitter-julia 0.23.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Syntax tokens are called *captures* in tree-sitter jargon. The following table l
 | operator | yes |
 | punctuation.bracket | yes | `()`, `[]`, `{}` |
 | punctuation.delimiter | yes | `,`, `;` |
-| punctuation.special | yes | `.`, `...`, `::`, string interpolation: `$()` |
+| punctuation.special | yes | string interpolation: `$()` |
 | string | yes |
 | string.escape | yes | escape sequence |
 | string.special | yes | command literal |

--- a/extension.toml
+++ b/extension.toml
@@ -1,14 +1,14 @@
 id = "julia"
 name = "Julia"
 description = "Julia support."
-version = "0.1.2"
+version = "0.1.3"
 schema_version = 1
 authors = ["Paul Berg <paul@plutojl.org>"]
 repository = "https://github.com/JuliaEditorSupport/zed-julia"
 
 [grammars.julia]
 repository = "https://github.com/tree-sitter/tree-sitter-julia"
-commit = "acd5ca12cc278df7960629c2429a096c7ac4bbea"
+commit = "e01c928d11375513138a175a68485c4d53e55ea9"
 
 [language_servers.julia]
 languages = ["Julia"]

--- a/languages/julia/highlights.scm
+++ b/languages/julia/highlights.scm
@@ -374,7 +374,7 @@
   (macro_identifier "@" (identifier)) @function.macro
   (macro_argument_list
     .
-    (string_literal) @comment.doc))
+    [(string_literal) (prefixed_string_literal)] @comment.doc))
   (#eq? @function.macro "@doc"))
 
 ; (2) docstrings preceding documentable elements at the top of a source file:

--- a/languages/julia/highlights.scm
+++ b/languages/julia/highlights.scm
@@ -44,11 +44,9 @@
   (#any-of? @_pipe "|>" ".|>"))
 
 ; Macros
-(macro_identifier) @function.macro
-
-; Zed - added: Highlight the macro name, not just the @
 (macro_identifier
-  (identifier) @function.macro)
+  "@" @function.macro
+  (_) @function.macro)
 
 (macro_definition
   (signature
@@ -65,21 +63,7 @@
     "setglobal!" "setglobalonce!" "swapfield!" "swapglobal!" "throw" "tuple" "typeassert" "typeof"))
 
 ; Type definitions
-(abstract_definition
-  name: (identifier) @type.definition) @keyword
-
-(primitive_definition
-  name: (identifier) @type.definition) @keyword
-
-(struct_definition
-  name: (identifier) @type.definition)
-
-(type_clause
-  [
-    (identifier) @type
-    (field_expression
-      (identifier) @type .)
-  ])
+(type_head (_) @type.definition)
 
 ; Type annotations
 (parametrized_type_expression
@@ -91,21 +75,20 @@
   (curly_expression
     (_) @type))
 
-(type_parameter_list
-  (identifier) @type)
-
 (typed_expression
   (identifier) @type .)
 
 (unary_typed_expression
   (identifier) @type .)
 
-(where_clause
-  (identifier) @type)
+(where_expression
+  (_) @type .)
 
-(where_clause
-  (curly_expression
-    (_) @type))
+(binary_expression
+  (_) @type
+  (operator) @operator
+  (_) @type
+  (#any-of? @operator "<:" ">:"))
 
 ; Built-in types
 ; filter(name -> typeof(Base.eval(Core, name)) in [DataType, UnionAll], names(Core))
@@ -235,11 +218,14 @@
 (export_statement
   "export" @keyword.import)
 
+(public_statement
+  "public" @keyword.import)
+
 (import_statement
-  [
-    "import"
-    "using"
-  ] @keyword.import)
+  "import" @keyword.import)
+
+(using_statement
+  "using" @keyword.import)
 
 (import_alias
   "as" @keyword.import)
@@ -254,14 +240,22 @@
     "end"
   ] @keyword) ; Zed - changed `@keyword.type` to `@keyword`
 
+(abstract_definition
+  [
+    "abstract"
+    "type"
+    "end"
+  ] @keyword.type)
+
+(primitive_definition
+  [
+    "primitive"
+    "type"
+    "end"
+  ] @keyword.type)
 
 ; Operators & Punctuation
-[
-  "->"
-  "="
-  "∈"
-  (operator)
-] @operator
+(operator) @operator
 
 (adjoint_expression
   "'" @operator)
@@ -269,11 +263,14 @@
 (range_expression
   ":" @operator)
 
+(arrow_function_expression
+  "->" @operator)
+
 [
   "."
   "..."
   "::"
-] @punctuation.special
+] @punctuation
 
 [
   ","
@@ -299,7 +296,8 @@
 
 ; Zed - added: Match the dot in the @. macro
 (macro_identifier
-  (operator) @function.macro (#eq? @function.macro "."))
+  "@"
+  (operator "." @function.macro))
 
 ; Zed - added: Function definitions
 ; (1) `function foo end` after docstrings
@@ -332,12 +330,6 @@
 ; Keyword operators
 ((operator) @keyword.operator
   (#any-of? @keyword.operator "in" "isa"))
-
-(for_binding
-  "in" @keyword.operator)
-
-(where_clause
-  "where" @keyword.operator)
 
 (where_expression
   "where" @keyword.operator)
@@ -386,19 +378,9 @@
   (#eq? @function.macro "@doc"))
 
 ; (2) docstrings preceding documentable elements at the top of a source file:
-((source_file
-  ; The Docstring:
-  [
-    (string_literal) @comment.doc
-    ; Workaroud: Find strings stolen as the last argument to a preceding macro
-    ; https://github.com/tree-sitter/tree-sitter-julia/issues/150
-    (macrocall_expression
-      (macro_argument_list
-      (_)+
-      (string_literal) @comment.doc .))
-  ]
+(source_file
+  (string_literal) @comment.doc
   .
-  ; The documentable element:
   [
     (assignment)
     (const_statement)
@@ -413,22 +395,11 @@
     (open_tuple
       (identifier))
   ])
-  (#match? @comment.doc "^\"\"\""))
 
 ; (3) docstrings preceding documentable elements at the top of a module:
-((module_definition
-  ; The Docstring:
-  [
-    (string_literal) @comment.doc
-    ; Workaroud: Find strings stolen as the last argument to a preceding macro
-    ; https://github.com/tree-sitter/tree-sitter-julia/issues/150
-    (macrocall_expression
-      (macro_argument_list
-      (_)+
-      (string_literal) @comment.doc .))
-  ]
+(module_definition
+  (string_literal) @comment.doc
   .
-  ; The documentable element:
   [
     (assignment)
     (const_statement)
@@ -443,7 +414,6 @@
     (open_tuple
       (identifier))
   ])
-  (#match? @comment.doc "^\"\"\""))
 
 [
   (line_comment)

--- a/languages/julia/injections.scm
+++ b/languages/julia/injections.scm
@@ -48,11 +48,29 @@
   ])
   (#set! "language" "markdown"))
 
+; HTML Language Injection
+((prefixed_string_literal
+  prefix: (identifier) @_prefix) @content
+  (#eq? @_prefix "html")
+  (#set! "language" "html"))
+
+; LaTeX Language Injection (LaTeXStrings.jl)
+((prefixed_string_literal
+  prefix: (identifier) @_prefix) @content
+  (#eq? @_prefix "L")
+  (#set! "language" "latex"))
+
 ; Markdown Language Injection
 ((prefixed_string_literal
   prefix: (identifier) @_prefix) @content
   (#eq? @_prefix "md")
   (#set! "language" "markdown"))
+
+; Python Language Injection (PyCall.jl)
+((prefixed_string_literal
+  prefix: (identifier) @_prefix) @content
+  (#eq? @_prefix "py")
+  (#set! "language" "python"))
 
 ; Regex Language Injection
 ((prefixed_string_literal
@@ -60,7 +78,7 @@
   (#eq? @_prefix "r")
   (#set! "language" "regex"))
 
-; SQL Language Injection
+; SQL Language Injection (SQLStrings.jl)
 ((prefixed_command_literal
   prefix: (identifier) @_prefix) @content
   (#eq? @_prefix "sql")

--- a/languages/julia/injections.scm
+++ b/languages/julia/injections.scm
@@ -4,7 +4,7 @@
   (macro_identifier "@" (identifier)) @_macro
   (macro_argument_list
     .
-    (string_literal) @content))
+    [(string_literal) (prefixed_string_literal)] @content))
   (#eq? @_macro "@doc")
   (#set! "language" "markdown"))
 

--- a/languages/julia/injections.scm
+++ b/languages/julia/injections.scm
@@ -8,21 +8,10 @@
   (#eq? @_macro "@doc")
   (#set! "language" "markdown"))
 
-
 ; docstrings preceding documentable elements at the top of a source file:
 ((source_file
-  ; The Docstring:
-  [
-    (string_literal) @content
-    ; Workaroud: Find strings stolen as the last argument to a preceding macro
-    ; https://github.com/tree-sitter/tree-sitter-julia/issues/150
-    (macrocall_expression
-      (macro_argument_list
-      (_)+
-      (string_literal) @content .))
-  ]
+  (string_literal) @content
   .
-  ; The documentable element:
   [
     (assignment)
     (const_statement)
@@ -37,23 +26,12 @@
     (open_tuple
       (identifier))
   ])
-  (#match? @content "^\"\"\"")
   (#set! "language" "markdown"))
 
 ; docstrings preceding documentable elements at the top of a module:
 ((module_definition
-  ; The Docstring:
-  [
-    (string_literal) @content
-    ; Workaroud: Find strings stolen as the last argument to a preceding macro
-    ; https://github.com/tree-sitter/tree-sitter-julia/issues/150
-    (macrocall_expression
-      (macro_argument_list
-      (_)+
-      (string_literal) @content .))
-  ]
+  (string_literal) @content
   .
-  ; The documentable element:
   [
     (assignment)
     (const_statement)
@@ -68,7 +46,12 @@
     (open_tuple
       (identifier))
   ])
-  (#match? @content "^\"\"\"")
+  (#set! "language" "markdown"))
+
+; Markdown Language Injection
+((prefixed_string_literal
+  prefix: (identifier) @_prefix) @content
+  (#eq? @_prefix "md")
   (#set! "language" "markdown"))
 
 ; Regex Language Injection

--- a/languages/julia/outline.scm
+++ b/languages/julia/outline.scm
@@ -1,5 +1,13 @@
+(using_statement
+  "using" @context
+  [
+   (selected_import (_) @name ":" @context)
+   (( [(identifier) (scoped_identifier) (import_path)] @name  "," @context)*
+      [(identifier) (scoped_identifier) (import_path)] @name)
+  ]) @item
+
 (import_statement
-  ["using" "import"] @context
+  "import" @context
   [
    (selected_import (_) @name ":" @context)
    (( [(identifier) (scoped_identifier) (import_path)] @name  "," @context)*
@@ -10,16 +18,26 @@
   ["module" "baremodule"] @context
   name: (identifier) @name) @item
 
-(primitive_definition
-  "primitive" @context
-  "type" @context
-  name: (identifier) @name) @item
-
 (abstract_definition
   "abstract" @context
   "type" @context
-  name: (identifier) @name
-  (type_clause)? @context) @item
+  (type_head
+    (binary_expression
+      .
+      (identifier) @name))) @item
+
+(primitive_definition
+  "primitive" @context
+  "type" @context
+  (type_head
+    (binary_expression
+      .
+      (identifier) @name))) @item
+
+(struct_definition
+  "mutable"? @context
+  "struct" @context
+  (type_head) @name) @item
 
 (function_definition
   "function" @context
@@ -62,12 +80,6 @@
       (argument_list)? @context)
     (_)* @context ; match the rest of the signature e.g., return_type
   )) @item
-
-(struct_definition
-  "mutable"? @context
-  "struct" @context
-  name: (_) @name
-  (type_parameter_list)? @context) @item
 
 (const_statement
   "const" @context

--- a/syntax-test-cases/docstrings.jl
+++ b/syntax-test-cases/docstrings.jl
@@ -96,8 +96,10 @@ struct A end
 
 struct A end
 
-# Special case when using the @doc macro:
+# Special cases when using the @doc macro:
 @doc "This _should_ have `markdown` injected!" foobar
+@doc """This _should_ have `markdown` injected!""" foobar
+@doc raw"""This _should_ have `markdown` injected!""" foobar
 
 # Docstrings may be single-quoted:
 "This _should_ have `markdown` injected!"

--- a/syntax-test-cases/docstrings.jl
+++ b/syntax-test-cases/docstrings.jl
@@ -57,12 +57,10 @@ end
 # (call_expression)
 foobar("This should _not_ have `markdown` injected!", x)
 
-
 """
 This _should_ have `markdown` injected!
 """
 @cxxdereference function f()
-
 end
 
 """
@@ -70,8 +68,8 @@ This _should_ have `markdown` injected!
 """
 @kwdef struct A end
 
-# BUG: As of Sep. 2024, top level macro calls will steal literals!
-# The string following this macro call is parsed as an argument to it.
+# A top level macro call may precede a docstring.
+# There was a bug that has been resolved, for the history see:
 # https://github.com/JuliaEditorSupport/zed-julia/issues/15
 @qmlfunction foobar
 
@@ -79,41 +77,32 @@ This _should_ have `markdown` injected!
 This _should_ have `markdown` injected!
 """
 struct A end
-# We highlight it (correctly) by querying for strings in macrocalls
-# where a valid target for docstrings immediately follow the macrocall.
 
-# BUT!
-# We don't highlight strings in macrocalls if they are the only argument,
-# because this setup is quite plausible:
+# We don't highlight single nor triple quoted strings in macro calls:
+# Example 1
 @info """
 This should _not_ have `markdown` injected!
 """
 
 struct A end
 
-# We also don't highlight single-quoted strings as docstrings in this setup,
-# because docstrings are _usually_ triple-quoted.
-# In other words, this is still highlighted correctly:
+# Example 2
 @foobar x "This should _not_ have `markdown` injected!"
 
 struct A end
 
-# However, this rare setup is currently highlighted INCORRECTLY.
+# Example 3
 @foobar "Yo" """This should _not_ have `markdown` injected!"""
 
 struct A end
 
-# Only the docstrings stolen by macros have this restriction applied, so
-# for example the following still works: (using the @doc macro)
+# Special case when using the @doc macro:
 @doc "This _should_ have `markdown` injected!" foobar
 
-# After cleaning up the queries, the single-quote restriction also applies
-# to top level docstrings preceding documentable items. The following is
-# highlighed INCORRECTLY:
+# Docstrings may be single-quoted:
 "This _should_ have `markdown` injected!"
 function foobar end
 
-# As is this:
 module X
 "This _should_ have `markdown` injected!"
 foobar

--- a/syntax-test-cases/edge-cases.jl
+++ b/syntax-test-cases/edge-cases.jl
@@ -1,0 +1,91 @@
+# Indices
+x[begin]
+x[begin:2]
+x[2:end]
+x[1:2]
+x[[begin, end]]
+begin
+    # this is a block, not an index
+end
+
+# ------------ 
+# Zed specials
+# ------------
+
+# Character literals
+# (highlight as @string)
+'w'
+
+# String interpolation
+# (highlight `$` and the outer parentheses as @punctuation.special)
+"$(sqrt(2))"
+
+# Macro calls
+# (highlight `@name` and `@.` as @function.macro)
+@info foo
+@. foo * bar
+
+# Function calls in pipes
+x = var .|> foo |> bar
+
+# Function definitions
+# (highlight the function name as @function.definition)
+function foo end
+function foo(x) 2x end
+function Base.foo(x) 2x end
+
+# Short function definitions
+# (highlight the function name as @function.definition
+# and the equal sign as @keyword.function)
+foo(x) = 2x
+foo(x)::Int = 2x
+foo(x::T) where {T<:Number} = 2x
+foo(x::T)::Int where {T<:Number} = 2x
+Base.foo(x) = 2x
+Base.foo(x)::Int = 2x
+Base.foo(x::T) where {T<:Number} = 2x
+Base.foo(x::T)::Int where {T<:Number} = 2x
+
+# ----------
+# Docstrings
+# ----------
+
+@doc """
+Docstring with `markdown`.
+"""
+foo10
+
+"""
+Docstring with `markdown`.
+"""
+foo11
+
+"""
+Docstring with `markdown`.
+"""
+foo12, foo13
+
+"""
+Docstring with `markdown`.
+"""
+function foo14 end
+
+"""
+Docstring with `markdown`.
+"""
+function foo15() end
+
+"""
+Docstring with `markdown`.
+"""
+function foo16(x) 2x end
+
+"""
+Docstring with `markdown`.
+"""
+@foobar function foo17() end
+
+"""
+Docstring with `markdown`.
+"""
+function Base.foo18() end


### PR DESCRIPTION
The upstream parser introduced some improvements and breaking changes. This PR requires the new parser 0.23.1 (see the updated commit field in `extension.toml`). For local testing, a compiled `tree-sitter-julia.wasm` is available [here](https://github.com/tree-sitter/tree-sitter-julia/releases/tag/v0.23.1).

Improvements:

- simplify some highlighting queries and add the `public` keyword (taken from upstream), closes #23 
- remove our workarounds as the parser fixes all known docstring issues
- adjust outline queries
- allow raw docstrings, closes #19 
- add html, latex, md & python injections, closes #20  
- add some syntax test cases (`edge-cases.jl`)
- bump our version to 0.1.3

If all looks good, we should push the update to the Zed extensions repo.