### PR TITLE
update on precompile failure

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "julia"
 name = "Julia"
 description = "Julia support."
-version = "0.1.3"
+version = "0.1.4"
 schema_version = 1
 authors = ["Paul Berg <paul@plutojl.org>"]
 repository = "https://github.com/JuliaEditorSupport/zed-julia"

--- a/src/julia.rs
+++ b/src/julia.rs
@@ -36,12 +36,12 @@ impl zed::Extension for JuliaExtension {
                 end
 
                 try
-                    Pkg.precompile()
+                    @eval using LanguageServer
                 catch
                     Pkg.update()
+                    @eval using LanguageServer
                 end
 
-                using LanguageServer
                 runserver()
                 "#
                 .to_string(),

--- a/src/julia.rs
+++ b/src/julia.rs
@@ -35,6 +35,12 @@ impl zed::Extension for JuliaExtension {
                     Pkg.add(Pkg.PackageSpec(uuid=ls_uuid))
                 end
 
+                try
+                    Pkg.precompile()
+                catch
+                    Pkg.update()
+                end
+
                 using LanguageServer
                 runserver()
                 "#


### PR DESCRIPTION
With the 1.11 update, previous environments cannot be loaded, so this forces an update of all packages.
