### PR TITLE
Add section "Using Zed in the REPL" to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,20 @@ Make sure that the Julia binary is on your ``PATH``.
 See [this document](./CONTRIBUTING.md).
 
 
+### Using Zed in the REPL
+
+Zed is currently not on the list of Julia's predefined editors. You can add it to your `~/.julia/config/startup.jl`:
+
+```julia
+atreplinit() do repl
+    InteractiveUtils.define_editor("zed") do cmd, path, line, column
+        `$cmd $path:$line:$column`
+    end
+end
+```
+
+Set the environment variable EDITOR (or VISUAL or JULIA_EDITOR, whatever you use) to `zed --wait`. Then, using `InteractiveUtils.edit` etc. will open the document in Zed.
+
 ### Customizing syntax highlighting
 
 You can change the foreground color and text attributes of syntax tokens in your `~/.config/zed/settings.json`, for instance:


### PR DESCRIPTION
It's a bit tricky to figure out how to add Zed to InteractiveUtils' list of editors so, I suggest adding this hint to our README.

@Pangoraw: for me, it's also tricky to push updates to the zed/extensions repo. I saw a CI workflow for that but I figured it was easier to write a short fish function to do that on my local machine. I can push your last #25  and this one later today…