### PR TITLE
Highlight field expression types

### DIFF
--- a/languages/julia/highlights.scm
+++ b/languages/julia/highlights.scm
@@ -68,15 +68,27 @@
 ; Type annotations
 (parametrized_type_expression
   [
-   (identifier) @type
-   (field_expression
-     (identifier) @type .)
+    (identifier) @type
+    (field_expression (identifier) @type (identifier) @type)
+    (field_expression ((field_expression (identifier) @type (identifier) @type) (identifier) @type))
+    (_) @type
   ]
   (curly_expression
-    (_) @type))
+    [
+      (identifier) @type
+      (field_expression (identifier) @type (identifier) @type)
+      (field_expression ((field_expression (identifier) @type (identifier) @type) (identifier) @type))
+      (_) @type
+    ]))
 
 (typed_expression
-  (identifier) @type .)
+  (identifier)
+    [
+      (identifier) @type ; x::T, it tags T as type
+      (field_expression (identifier) @type (identifier) @type) ; x::Module.T, it tags Module and T as type
+      (field_expression ((field_expression (identifier) @type (identifier) @type) (identifier) @type)) ; x::Module.SubModule.T
+      (_) @type ; should tag anything as type (but does not work because the most specific match seems to have priority)
+    ])
 
 (unary_typed_expression
   (identifier) @type .)

--- a/syntax-test-cases/edge-cases.jl
+++ b/syntax-test-cases/edge-cases.jl
@@ -8,7 +8,7 @@ begin
     # this is a block, not an index
 end
 
-# ------------ 
+# ------------
 # Zed specials
 # ------------
 
@@ -31,8 +31,30 @@ x = var .|> foo |> bar
 # Function definitions
 # (highlight the function name as @function.definition)
 function foo end
-function foo(x) 2x end
-function Base.foo(x) 2x end
+function foo(x)
+    2x
+end
+function Base.foo(x)
+    2x
+end
+
+# Types
+struct Bar
+    a::T
+    b::Module.T # pass
+    c::Module.Submodule.T # pass
+    d::Module.Submodule.SubModule.SubSubModule.T # broken
+    e::Module.Submodule.T{Int} # pass
+    f::Module.Submodule.T{Module.Int} # pass
+    g::Module.Submodule.T{Module.SubModule.Int} # pass
+    h::Module.Submodule.T{Module.SubModule.SubSubModule.Int} # broken
+end
+
+function bar(w::T) end
+function bar(x::Module.T) nothing end
+function bar(y::Module.Submodule.T) nothing end
+function bar(z::Module.Submodule.T{Int}) nothing end
+
 
 # Short function definitions
 # (highlight the function name as @function.definition
@@ -89,3 +111,5 @@ Docstring with `markdown`.
 Docstring with `markdown`.
 """
 function Base.foo18() end
+
+module A end


### PR DESCRIPTION
Hey,

I'm using zed for a while and love to write Julia code with this editor.

However, when I write something like `x::Module.T`, the type `Module.T` is not highlighted and it's annoying.

So I took the evening off to understand how tree sitter and the highlight.
Here is a suggestion for fixing a part of the bug.

You see the difference before and after with the two following screenshots.

**before**
<img width="733" alt="Capture d’écran 2024-12-20 à 23 22 23" src="https://github.com/user-attachments/assets/a7ef7083-0409-4c2a-9974-8f72a37b495c" />
**after**
<img width="696" alt="Capture d’écran 2024-12-20 à 23 21 35" src="https://github.com/user-attachments/assets/b7033932-5aba-41df-ab5d-7c99ffd612a8" />

As you can see I could not make it recursive because I could not find a way to give the `@type` tag priority over the `@variable.member` tag. The most specific match seems to take precedence.

It's far from perfect but it improves the current behavior and I guess `Module.SubModule.T` is enough for 80% of users.
I'm opening it as a draft PR because somebody here might have the solution.

