### PR TITLE
update tree-sitter-julia

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,14 +1,14 @@
 id = "julia"
 name = "Julia"
 description = "Julia support."
-version = "0.1.4"
+version = "0.1.5"
 schema_version = 1
 authors = ["Paul Berg <paul@plutojl.org>"]
 repository = "https://github.com/JuliaEditorSupport/zed-julia"
 
 [grammars.julia]
 repository = "https://github.com/tree-sitter/tree-sitter-julia"
-commit = "e01c928d11375513138a175a68485c4d53e55ea9"
+commit = "18b739c1563c83fc816170a4241adfa4b69e5c47"
 
 [language_servers.julia]
 languages = ["Julia"]

--- a/languages/julia/config.toml
+++ b/languages/julia/config.toml
@@ -20,7 +20,7 @@ brackets = [
         "comment",
         "string",
     ] },
-    { start = "#=", end = " =#", close = true, newline = false, not_in = [
+    { start = "#=", end = "=#", close = true, newline = false, not_in = [
         "comment",
         "string",
     ] },

--- a/languages/julia/outline.scm
+++ b/languages/julia/outline.scm
@@ -2,16 +2,16 @@
   "using" @context
   [
    (selected_import (_) @name ":" @context)
-   (( [(identifier) (scoped_identifier) (import_path)] @name  "," @context)*
-      [(identifier) (scoped_identifier) (import_path)] @name)
+   (( [(identifier) (import_path)] @name  "," @context)*
+      [(identifier) (import_path)] @name)
   ]) @item
 
 (import_statement
   "import" @context
   [
    (selected_import (_) @name ":" @context)
-   (( [(identifier) (scoped_identifier) (import_path)] @name  "," @context)*
-      [(identifier) (scoped_identifier) (import_path)] @name)
+   (( [(identifier) (import_path)] @name  "," @context)*
+      [(identifier) (import_path)] @name)
   ]) @item
 
 (module_definition


### PR DESCRIPTION
`scoped_identifier` has been removed within
tree-sitter/tree-sitter-julia#170.

Also tweaks multiline comment ending pattern
so that it does not insert unnecessary extra
whitespace.