### PR TITLE
Add support for struct field docstrings

### DIFF
--- a/languages/julia/highlights.scm
+++ b/languages/julia/highlights.scm
@@ -415,6 +415,12 @@
       (identifier))
   ])
 
+; (4) struct field docstrings:
+(struct_definition
+  (string_literal) @comment.doc
+  .
+  [(identifier) (typed_expression)])
+
 [
   (line_comment)
   (block_comment)

--- a/languages/julia/injections.scm
+++ b/languages/julia/injections.scm
@@ -50,7 +50,7 @@
 
 ; struct field docstrings:
 ((struct_definition
-  (string_literal) @content
+  (string_literal) @injection.content
   .
   [(identifier) (typed_expression)])
   (#set! injection.language "markdown"))

--- a/languages/julia/injections.scm
+++ b/languages/julia/injections.scm
@@ -48,6 +48,13 @@
   ])
   (#set! injection.language "markdown"))
 
+; struct field docstrings:
+((struct_definition
+  (string_literal) @content
+  .
+  [(identifier) (typed_expression)])
+  (#set! injection.language "markdown"))
+
 ; HTML Language Injection
 ((prefixed_string_literal
   prefix: (identifier) @_prefix

--- a/syntax-test-cases/docstrings.jl
+++ b/syntax-test-cases/docstrings.jl
@@ -78,6 +78,27 @@ This _should_ have `markdown` injected!
 """
 struct A end
 
+struct FieldDocstring1
+    """
+    This _should_ have `markdown` injected!
+    """
+    x
+end
+
+struct FieldDocstring2
+    """
+    This _should_ have `markdown` injected!
+    """
+    x::Int
+end
+
+struct FieldDocstring3{T}
+    """
+    This _should_ have `markdown` injected!
+    """
+    x::T
+end
+
 # We don't highlight single nor triple quoted strings in macro calls:
 # Example 1
 @info """


### PR DESCRIPTION
- Add injection pattern for docstrings above struct fields
- Support both untyped fields (e.g., `x`) and typed fields (e.g., `x::Int`)
- Add test cases demonstrating the new functionality
