### PR TITLE
add auto-close support for triple quote string

### DIFF
--- a/languages/julia/config.toml
+++ b/languages/julia/config.toml
@@ -9,6 +9,7 @@ brackets = [
     { start = "[", end = "]", close = true, newline = true },
     { start = "(", end = ")", close = true, newline = true },
     { start = "\"\"\"", end = "\n\"\"\"", close = true, newline = true },
+    { start = "```", end = "\n```", close = true, newline = true },
     { start = "\"", end = "\"", close = true, newline = false, not_in = ["comment", "string"] },
     { start = "'", end = "'", close = true, newline = false, not_in = ["comment", "string"] },
     { start = "`", end = "`", close = true, newline = false, not_in = ["comment", "string"] },

--- a/languages/julia/config.toml
+++ b/languages/julia/config.toml
@@ -8,22 +8,11 @@ brackets = [
     { start = "{", end = "}", close = true, newline = true },
     { start = "[", end = "]", close = true, newline = true },
     { start = "(", end = ")", close = true, newline = true },
-    { start = "\"", end = "\"", close = true, newline = false, not_in = [
-        "comment",
-        "string",
-    ] },
-    { start = "'", end = "'", close = true, newline = false, not_in = [
-        "comment",
-        "string",
-    ] },
-    { start = "`", end = "`", close = true, newline = false, not_in = [
-        "comment",
-        "string",
-    ] },
-    { start = "#=", end = "=#", close = true, newline = false, not_in = [
-        "comment",
-        "string",
-    ] },
+    { start = "\"\"\"", end = "\n\"\"\"", close = true, newline = true },
+    { start = "\"", end = "\"", close = true, newline = false, not_in = ["comment", "string"] },
+    { start = "'", end = "'", close = true, newline = false, not_in = ["comment", "string"] },
+    { start = "`", end = "`", close = true, newline = false, not_in = ["comment", "string"] },
+    { start = "#=", end = "=#", close = true, newline = false, not_in = ["comment", "string"] },
 ]
 collapsed_placeholder = "# ..."
 tab_size = 4


### PR DESCRIPTION
Note that this setting needs to be come before:
```toml
{ start = "\"", end = "\"", close = true, newline = false, not_in = ["comment", "string"] },
```
Otherwise the auto close doesn't work for some reason.