### PR TITLE
Implement comprehensive indentation configuration for Julia

### DIFF
--- a/languages/julia/config.toml
+++ b/languages/julia/config.toml
@@ -17,3 +17,50 @@ brackets = [
 ]
 collapsed_placeholder = "# ..."
 tab_size = 4
+
+# Indentation Configuration
+# ========================
+# Zed uses BOTH regex patterns (`config.toml`) and Tree-sitter queries (`indents.scm`) for indentation.
+#
+# Why Both Are Needed:
+# Based on Zed's Python implementation (PR #29625, #33370), regex patterns were introduced because:
+# 1. Tree-sitter has upstream parsing inconsistencies (e.g., Python issue #33238 with comments)
+# 2. The previous `significant_indentation` approach was "unnecessarily complicated to maintain"
+# 3. Tree-sitter alone cannot provide immediate feedback while typing incomplete code
+# 4. Complex nested structures need context-aware outdenting that's simpler with regex
+#
+# For Julia, we face similar challenges. Consider this case:
+# ```julia
+# if x
+# elseif y
+#     elseif z| <- just finished typing `z`
+# end
+# ```
+# Here, Tree-sitter might not recognize the incomplete line as an `elseif_clause` yet,
+# so `@outdent` won't trigger. The regex pattern matches immediately and outdents.
+#
+# This dual approach is intentional - Tree-sitter provides structural understanding
+# for complete code, while regex patterns handle the interactive typing experience:
+#
+# 1. `increase_indent_pattern`: Regex that matches lines after which indentation should increase
+#    - Applied when you press Enter after these patterns
+#    - Also tracks which keyword started each block (for use with `decrease_indent_patterns`)
+#
+# 2. `decrease_indent_patterns`: Context-aware outdenting with `valid_after`
+#    - REQUIRES corresponding `@start.suffix` captures in `indents.scm` (e.g., `@start.if`, `@start.function`)
+#    - REQUIRES `valid_after` to be specified - won't work without it
+#    - Aligns the matched line with the most recent valid predecessor
+#    - Example: `else` with `valid_after=["if","elseif"]` aligns to the nearest `if`/`elseif`
+#
+# Note: `decrease_indent_patterns` without `valid_after` will NOT work - this is by design in Zed.
+# It needs to know which block to align with, not just "decrease by one level".
+
+increase_indent_pattern = "^\\s*(function|if|elseif|else|for|while|begin|let|do|try|catch|finally|struct|mutable\\s+struct|quote|macro|module|baremodule|abstract\\s+type|primitive\\s+type)\\b.*$"
+
+decrease_indent_patterns = [
+    { pattern = "^\\s*elseif\\b.*", valid_after = ["if", "elseif"] },
+    { pattern = "^\\s*else\\b.*", valid_after = ["if", "elseif", "try", "catch"] },
+    { pattern = "^\\s*catch\\b.*", valid_after = ["try"] },
+    { pattern = "^\\s*finally\\b.*", valid_after = ["try", "catch"] },
+    { pattern = "^\\s*end\\b.*", valid_after = ["function", "if", "for", "while", "begin", "let", "do", "try", "struct", "macro", "quote"] }
+]

--- a/languages/julia/indents.scm
+++ b/languages/julia/indents.scm
@@ -1,25 +1,38 @@
+; `@start.xxx` marks where these clauses start for `valid_after` matching in config.toml
+
 [
   (struct_definition
+    "struct" @start.struct
     "end" @end)
   (macro_definition
+    "macro" @start.macro
     "end" @end)
   (function_definition
+    "function" @start.function
     "end" @end)
   (compound_statement
+    "begin" @start.begin
     "end" @end)
   (if_statement
+    "if" @start.if
     "end" @end)
   (try_statement
+    "try" @start.try
     "end" @end)
   (for_statement
+    "for" @start.for
     "end" @end)
   (while_statement
+    "while" @start.while
     "end" @end)
   (let_statement
+    "let" @start.let
     "end" @end)
   (quote_statement
+    "quote" @start.quote
     "end" @end)
   (do_clause
+    "do" @start.do
     "end" @end)
   (assignment)
   (for_binding)
@@ -35,9 +48,8 @@
 (_ "{" "}" @end) @indent
 (_ "(" ")" @end) @indent
 
-[
-  (else_clause)
-  (elseif_clause)
-  (catch_clause)
-  (finally_clause)
-] @outdent
+; `@start.xxx` marks where these clauses start for `valid_after` matching in config.toml
+(else_clause "else" @start.else) @outdent
+(elseif_clause "elseif" @start.elseif) @outdent
+(catch_clause "catch" @start.catch) @outdent
+(finally_clause "finally" @start.finally) @outdent

--- a/languages/julia/indents.scm
+++ b/languages/julia/indents.scm
@@ -48,8 +48,9 @@
 (_ "{" "}" @end) @indent
 (_ "(" ")" @end) @indent
 
-; `@start.xxx` marks where these clauses start for `valid_after` matching in config.toml
-(else_clause "else" @start.else) @outdent
-(elseif_clause "elseif" @start.elseif) @outdent
-(catch_clause "catch" @start.catch) @outdent
-(finally_clause "finally" @start.finally) @outdent
+[
+  (else_clause)
+  (elseif_clause)
+  (catch_clause)
+  (finally_clause)
+] @outdent


### PR DESCRIPTION
This commit adds both regex-based and Tree-sitter-based indentation rules to provide a smooth editing experience for Julia coding in Zed.

Motivation - this didn't work properly before:
```julia
if x
elseif y
    else    # <- wouldn't auto-outdent
end
```

Changes:
- Add `increase_indent_pattern` for Julia block keywords
- Add `decrease_indent_patterns` with context-aware `valid_after` rules
- Add `@start.suffix` captures in indents.scm for tracking block beginnings (required for `decrease_indent_patterns` to be functional)
- Update `@outdent` patterns to work with specific keywords

The dual approach (regex + Tree-sitter) is intentional, following Zed's design pattern established for Python (see zed-industries/zed#29625, zed-industries/zed#33370).