### PR TITLE
outline: support outline for `@testset` and `include`s

### DIFF
--- a/languages/julia/outline.scm
+++ b/languages/julia/outline.scm
@@ -87,3 +87,19 @@
     (_) @name
     (operator)
     (_))) @item
+
+; Test sets - show test organization in outline
+(macrocall_expression
+  (macro_identifier "@" (identifier) @_macro)
+  (#eq? @_macro "testset")) @name @item
+
+; ; Individual tests - show full @test expression
+; (macrocall_expression
+;   (macro_identifier "@" (identifier) @_macro)
+;   (#eq? @_macro "test")) @name @item
+
+; Include statements - useful for navigating file structure
+(call_expression
+  (identifier) @_call @context
+  (argument_list) @name
+  (#eq? @_call "include")) @item


### PR DESCRIPTION
Makes it easier to get an overview of test/file structure.

<img width="963" alt="Screenshot 2025-06-30 at 19 15 35" src="https://github.com/user-attachments/assets/9146f62d-097a-46c8-ad7a-628f8b556579" />
