### PR TITLE
use `markdown-inline` instead of `markdown` for docstring injection

### DIFF
--- a/languages/julia/injections.scm
+++ b/languages/julia/injections.scm
@@ -6,7 +6,7 @@
     .
     [(string_literal) (prefixed_string_literal)] @injection.content))
   (#eq? @_macro "@doc")
-  (#set! injection.language "markdown"))
+  (#set! injection.language "markdown-inline"))
 
 ; docstrings preceding documentable elements at the top of a source file:
 ((source_file
@@ -26,7 +26,7 @@
     (open_tuple
       (identifier))
   ])
-  (#set! injection.language "markdown"))
+  (#set! injection.language "markdown-inline"))
 
 ; docstrings preceding documentable elements at the top of a module:
 ((module_definition
@@ -46,14 +46,14 @@
     (open_tuple
       (identifier))
   ])
-  (#set! injection.language "markdown"))
+  (#set! injection.language "markdown-inline"))
 
 ; struct field docstrings:
 ((struct_definition
   (string_literal) @injection.content
   .
   [(identifier) (typed_expression)])
-  (#set! injection.language "markdown"))
+  (#set! injection.language "markdown-inline"))
 
 ; HTML Language Injection
 ((prefixed_string_literal


### PR DESCRIPTION
If we don't do this, in the latest Zed, regular markdown highlighting will be applied to docstrings, causing them to be highlighted like actual code rather than comments, which significantly reduces readability.

| Before | This PR |
| ------ | ------- |
| <img width="870" height="498" alt="Screenshot 2025-09-10 at 21 11 49" src="https://github.com/user-attachments/assets/34d54d8a-17fb-48cd-89c8-32ead7bf847f" /> | <img width="870" height="498" alt="Screenshot 2025-09-10 at 21 10 10" src="https://github.com/user-attachments/assets/6d0906e2-2b10-4bcc-a173-a7bb16d4ad62" /> |


(This can probably be reproduced from zed-industries/zed#37669 onwards)