### PR TITLE
add highlights for module names and `@goto`/`@label` targets

### DIFF
--- a/languages/julia/highlights.scm
+++ b/languages/julia/highlights.scm
@@ -204,6 +204,17 @@
     "end"
   ] @keyword.import)
 
+; Zed - added: Module name as type
+(module_definition
+  ["module" "baremodule"]
+  (identifier) @type)
+
+; Zed - added: @goto/@label target labels
+((macrocall_expression
+  (macro_identifier "@" @function.macro (identifier) @_name @function.macro)
+  (macro_argument_list (identifier) @label))
+  (#any-of? @_name "goto" "label"))
+
 (export_statement
   "export" @keyword.import)
 


### PR DESCRIPTION
- Highlight module names as `@type`
- Highlight `@goto`/`@label` target identifiers as `@label`

> `module` highlight example
<img width="479" height="234" alt="Screenshot 2026-01-02 at 16 39 38" src="https://github.com/user-attachments/assets/56300008-5c37-4f53-bc88-7d2330e3754f" />

> `@label` highlight example
<img width="479" height="234" alt="Screenshot 2026-01-02 at 16 39 52" src="https://github.com/user-attachments/assets/7f123c25-2dbf-45e2-961a-962a004255eb" />
