### PR TITLE
Add language server workspace configuration

### DIFF
--- a/src/julia.rs
+++ b/src/julia.rs
@@ -52,10 +52,10 @@ impl zed::Extension for JuliaExtension {
 
     fn language_server_workspace_configuration(
         &mut self,
-        _language_server_id: &LanguageServerId,
+        server_id: &LanguageServerId,
         worktree: &zed::Worktree,
     ) -> Result<Option<zed::serde_json::Value>> {
-        let settings = LspSettings::for_worktree("julia", worktree)
+        let settings = LspSettings::for_worktree(server_id.as_ref(), worktree)
             .ok()
             .and_then(|lsp_settings| lsp_settings.settings)
             .unwrap_or_default();

--- a/src/julia.rs
+++ b/src/julia.rs
@@ -1,5 +1,5 @@
 use zed::{CodeLabel, LanguageServerId};
-use zed_extension_api::{self as zed, Result};
+use zed_extension_api::{self as zed, settings::LspSettings, Result};
 
 struct JuliaExtension;
 
@@ -48,6 +48,18 @@ impl zed::Extension for JuliaExtension {
             ],
             env: Default::default(),
         })
+    }
+
+    fn language_server_workspace_configuration(
+        &mut self,
+        _language_server_id: &LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<Option<zed::serde_json::Value>> {
+        let settings = LspSettings::for_worktree("julia", worktree)
+            .ok()
+            .and_then(|lsp_settings| lsp_settings.settings)
+            .unwrap_or_default();
+        Ok(Some(settings))
     }
 
     fn label_for_completion(


### PR DESCRIPTION
Hi,

Thanks a lot for all the efforts on the extension! 

One of the issues I have is that I am getting many "missing references" from the language server. This is mostly because of issues unrelated with the extension (mainly because of Parameter.jl macros) and I'm getting the same in VS Code. My solution there was to just turn off missing references in the linter as they are mostly just false flags. 

I did not manage to to the same here with any settings combination I tried. Finally, I realized that this extension does not forward the settings from Zed to LanguageServer.jl. 

This PR fixes this by setting up  `language_server_workspace_configuration`, which is read by the language server. This follows the exact same approach of the HTML package (https://github.com/zed-industries/zed/blob/main/extensions/html/src/html.rs#L93 ).

With the PR, settings like these should be passed along to the language server. 

```
"lsp": {
  "julia": {
    "settings": {
      "julia.lint.missingrefs": "none"
    }
  }
}
```


