### PR TITLE
Bugfix outline and macro highlights

### DIFF
--- a/languages/julia/highlights.scm
+++ b/languages/julia/highlights.scm
@@ -45,9 +45,10 @@
 
 (macro_definition
   (signature
-    (call_expression
-      .
-      (identifier) @function.macro)))
+    [
+      (call_expression . (identifier) @function.macro)
+      (typed_expression . (call_expression . (identifier) @function.macro))
+    ]))
 
 ; Built-in functions
 ; print.("\"", filter(name -> getglobal(Core, name) isa Core.Builtin, names(Core)), "\" ")
@@ -321,6 +322,12 @@
       (identifier) @function.definition
       (call_expression (identifier) @function.definition)
       (call_expression (field_expression (identifier) @function.definition .))
+      (typed_expression . (call_expression (identifier) @function.definition))
+      (typed_expression . (call_expression (field_expression (identifier) @function.definition .)))
+      (where_expression . (call_expression (identifier) @function.definition))
+      (where_expression . (call_expression (field_expression (identifier) @function.definition .)))
+      (where_expression . (typed_expression . (call_expression (identifier) @function.definition)))
+      (where_expression . (typed_expression . (call_expression (field_expression (identifier) @function.definition .))))
     ]))
 
 ; Zed - added: Short function definitions like `foo(x) = 2x`

--- a/languages/julia/highlights.scm
+++ b/languages/julia/highlights.scm
@@ -48,6 +48,8 @@
     [
       (call_expression . (identifier) @function.macro)
       (typed_expression . (call_expression . (identifier) @function.macro))
+      (where_expression . (call_expression . (identifier) @function.macro))
+      (where_expression . (typed_expression . (call_expression . (identifier) @function.macro)))
     ]))
 
 ; Built-in functions

--- a/languages/julia/highlights.scm
+++ b/languages/julia/highlights.scm
@@ -43,15 +43,6 @@
   (identifier) @function.call
   (#any-of? @_pipe "|>" ".|>"))
 
-(macro_definition
-  (signature
-    [
-      (call_expression . (identifier) @function.macro)
-      (typed_expression . (call_expression . (identifier) @function.macro))
-      (where_expression . (call_expression . (identifier) @function.macro))
-      (where_expression . (typed_expression . (call_expression . (identifier) @function.macro)))
-    ]))
-
 ; Built-in functions
 ; print.("\"", filter(name -> getglobal(Core, name) isa Core.Builtin, names(Core)), "\" ")
 ((identifier) @function.builtin
@@ -97,7 +88,7 @@
   (assignment
     .
     (identifier) @constant))
-    
+
 ; Zed - moved after builtins to ensure macro highlights take precedence
 (macro_identifier
   "@" @function.macro
@@ -322,13 +313,15 @@
     .
     [
       (identifier) @function.definition
+      ; match `foo()` or `foo()::T` or `foo() where...` or `foo()::T where...`
       (call_expression (identifier) @function.definition)
-      (call_expression (field_expression (identifier) @function.definition .))
       (typed_expression . (call_expression (identifier) @function.definition))
-      (typed_expression . (call_expression (field_expression (identifier) @function.definition .)))
       (where_expression . (call_expression (identifier) @function.definition))
-      (where_expression . (call_expression (field_expression (identifier) @function.definition .)))
       (where_expression . (typed_expression . (call_expression (identifier) @function.definition)))
+      ; match `Base.foo()` or `Base.foo()::T` or `Base.foo() where...` or `Base.foo()::T where...`
+      (call_expression (field_expression (identifier) @function.definition .))
+      (typed_expression . (call_expression (field_expression (identifier) @function.definition .)))
+      (where_expression . (call_expression (field_expression (identifier) @function.definition .)))
       (where_expression . (typed_expression . (call_expression (field_expression (identifier) @function.definition .))))
     ]))
 
@@ -336,16 +329,28 @@
 (assignment
   .
   [
+    ; match `foo()` or `foo()::T` or `foo() where...` or `foo()::T where...`
     (call_expression (identifier) @function.definition)
     (typed_expression . (call_expression (identifier) @function.definition))
     (where_expression . (call_expression (identifier) @function.definition))
     (where_expression . (typed_expression . (call_expression (identifier) @function.definition)))
+    ; match `Base.foo()` or `Base.foo()::T` or `Base.foo() where...` or `Base.foo()::T where...`
     (call_expression (field_expression (identifier) @function.definition .))
     (typed_expression . (call_expression (field_expression (identifier) @function.definition .)))
     (where_expression . (call_expression (field_expression (identifier) @function.definition .)))
     (where_expression . (typed_expression . (call_expression (field_expression (identifier) @function.definition .))))
   ]
   (operator) @keyword.function)
+
+; Zed - added: Macro definition name highlighting
+(macro_definition
+  (signature
+    [
+      (call_expression . (identifier) @function.macro)
+      (typed_expression . (call_expression . (identifier) @function.macro))
+      (where_expression . (call_expression . (identifier) @function.macro))
+      (where_expression . (typed_expression . (call_expression . (identifier) @function.macro)))
+    ]))
 
 ; Keyword operators
 ((operator) @keyword.operator

--- a/languages/julia/outline.scm
+++ b/languages/julia/outline.scm
@@ -45,38 +45,16 @@
   "function" @context
   (signature
     [
-      (call_expression
-        [
-          (identifier) @name
-          (field_expression _+ @context (identifier) @name .)
-        ]
-        (argument_list)? @context)
-      (typed_expression
-        (call_expression
-          [
-            (identifier) @name
-            (field_expression _+ @context (identifier) @name .)
-          ]
-          (argument_list)? @context)
-        _+ @context)
-      (where_expression
-        (call_expression
-          [
-            (identifier) @name
-            (field_expression _+ @context (identifier) @name .)
-          ]
-          (argument_list)? @context)
-        _+ @context)
-      (where_expression
-        (typed_expression
-          (call_expression
-            [
-              (identifier) @name
-              (field_expression _+ @context (identifier) @name .)
-            ]
-            (argument_list)? @context)
-          _+ @context)
-        _+ @context)
+      ; match `foo()` or `foo()::T` or `foo() where...` or `foo()::T where...`
+      (call_expression (identifier) @name (argument_list)? @context)
+      (typed_expression (call_expression (identifier) @name (argument_list)? @context) _+ @context)
+      (where_expression (call_expression (identifier) @name (argument_list)? @context) _+ @context)
+      (where_expression (typed_expression (call_expression (identifier) @name (argument_list)? @context) _+ @context) _+ @context)
+      ; match `Base.foo()` or `Base.foo()::T` or `Base.foo() where...` or `Base.foo()::T where...`
+      (call_expression (field_expression _+ @context (identifier) @name .) (argument_list)? @context)
+      (typed_expression (call_expression (field_expression _+ @context (identifier) @name .) (argument_list)? @context) _+ @context)
+      (where_expression (call_expression (field_expression _+ @context (identifier) @name .) (argument_list)? @context) _+ @context)
+      (where_expression (typed_expression (call_expression (field_expression _+ @context (identifier) @name .) (argument_list)? @context) _+ @context) _+ @context)
     ]
   )) @item
 
@@ -102,38 +80,16 @@
   "macro" @context
   (signature
     [
-      (call_expression
-        [
-          (identifier) @name
-          (field_expression _+ @context (identifier) @name .)
-        ]
-        (argument_list)? @context)
-      (typed_expression
-        (call_expression
-          [
-            (identifier) @name
-            (field_expression _+ @context (identifier) @name .)
-          ]
-          (argument_list)? @context)
-        _+ @context)
-      (where_expression
-        (call_expression
-          [
-            (identifier) @name
-            (field_expression _+ @context (identifier) @name .)
-          ]
-          (argument_list)? @context)
-        _+ @context)
-      (where_expression
-        (typed_expression
-          (call_expression
-            [
-              (identifier) @name
-              (field_expression _+ @context (identifier) @name .)
-            ]
-            (argument_list)? @context)
-          _+ @context)
-        _+ @context)
+      ; match `foo()` or `foo()::T` or `foo() where...` or `foo()::T where...`
+      (call_expression (identifier) @name (argument_list)? @context)
+      (typed_expression (call_expression (identifier) @name (argument_list)? @context) _+ @context)
+      (where_expression (call_expression (identifier) @name (argument_list)? @context) _+ @context)
+      (where_expression (typed_expression (call_expression (identifier) @name (argument_list)? @context) _+ @context) _+ @context)
+      ; match `Base.foo()` or `Base.foo()::T` or `Base.foo() where...` or `Base.foo()::T where...`
+      (call_expression (field_expression _+ @context (identifier) @name .) (argument_list)? @context)
+      (typed_expression (call_expression (field_expression _+ @context (identifier) @name .) (argument_list)? @context) _+ @context)
+      (where_expression (call_expression (field_expression _+ @context (identifier) @name .) (argument_list)? @context) _+ @context)
+      (where_expression (typed_expression (call_expression (field_expression _+ @context (identifier) @name .) (argument_list)? @context) _+ @context) _+ @context)
     ]
   )) @item
 

--- a/languages/julia/outline.scm
+++ b/languages/julia/outline.scm
@@ -116,6 +116,24 @@
           ]
           (argument_list)? @context)
         _+ @context)
+      (where_expression
+        (call_expression
+          [
+            (identifier) @name
+            (field_expression _+ @context (identifier) @name .)
+          ]
+          (argument_list)? @context)
+        _+ @context)
+      (where_expression
+        (typed_expression
+          (call_expression
+            [
+              (identifier) @name
+              (field_expression _+ @context (identifier) @name .)
+            ]
+            (argument_list)? @context)
+          _+ @context)
+        _+ @context)
     ]
   )) @item
 

--- a/languages/julia/outline.scm
+++ b/languages/julia/outline.scm
@@ -39,16 +39,45 @@
   "struct" @context
   (type_head) @name) @item
 
+; Match long function definitions like `function foo(x) ... end`.
+; Handle all four combinations: plain, with return type, with where clause, or both.
 (function_definition
   "function" @context
   (signature
-    (call_expression
-      [
-        (identifier) @name ; match foo()
-        (field_expression _+ @context (identifier) @name .) ; match Base.foo()
-      ]
-      (argument_list)? @context)
-    (_)* @context ; match the rest of the signature e.g., return_type and/or where_clause
+    [
+      (call_expression
+        [
+          (identifier) @name
+          (field_expression _+ @context (identifier) @name .)
+        ]
+        (argument_list)? @context)
+      (typed_expression
+        (call_expression
+          [
+            (identifier) @name
+            (field_expression _+ @context (identifier) @name .)
+          ]
+          (argument_list)? @context)
+        _+ @context)
+      (where_expression
+        (call_expression
+          [
+            (identifier) @name
+            (field_expression _+ @context (identifier) @name .)
+          ]
+          (argument_list)? @context)
+        _+ @context)
+      (where_expression
+        (typed_expression
+          (call_expression
+            [
+              (identifier) @name
+              (field_expression _+ @context (identifier) @name .)
+            ]
+            (argument_list)? @context)
+          _+ @context)
+        _+ @context)
+    ]
   )) @item
 
 ; Match short function definitions like foo(x) = 2x.
@@ -72,13 +101,22 @@
 (macro_definition
   "macro" @context
   (signature
-    (call_expression
-      [
-        (identifier) @name ; match foo()
-        (field_expression _+ @context (identifier) @name .) ; match Base.foo()
-      ]
-      (argument_list)? @context)
-    (_)* @context ; match the rest of the signature e.g., return_type
+    [
+      (call_expression
+        [
+          (identifier) @name
+          (field_expression _+ @context (identifier) @name .)
+        ]
+        (argument_list)? @context)
+      (typed_expression
+        (call_expression
+          [
+            (identifier) @name
+            (field_expression _+ @context (identifier) @name .)
+          ]
+          (argument_list)? @context)
+        _+ @context)
+    ]
   )) @item
 
 (const_statement

--- a/syntax-test-cases/edge-cases.jl
+++ b/syntax-test-cases/edge-cases.jl
@@ -8,7 +8,7 @@ begin
     # this is a block, not an index
 end
 
-# ------------ 
+# ------------
 # Zed specials
 # ------------
 
@@ -33,6 +33,44 @@ x = var .|> foo |> bar
 function foo end
 function foo(x) 2x end
 function Base.foo(x) 2x end
+
+# Long function definitions with return types and where clauses
+# (highlight the function name as @function.definition)
+# (these should all show in the outline panel)
+function foo_plain(x)
+    return x + 1
+end
+
+function bar_typed(x)::String
+    return string(x)
+end
+
+function baz_typed(x::Int)::Int
+    return x * 2
+end
+
+function qux_typed(x::Int, y::Int)::Float64
+    return x / y
+end
+
+function quux_where(x::T) where T
+    return x + 1
+end
+
+function corge_both(x::T)::Int where T
+    return x * 2
+end
+
+# Macro definitions with return types and where clauses
+# (highlight the macro name as @function.macro)
+# (all should appear in outline)
+macro mymacro(ex)
+    return esc(ex)
+end
+
+macro typed_macro(ex)::Expr
+    return esc(ex)
+end
 
 # Short function definitions
 # (highlight the function name as @function.definition


### PR DESCRIPTION
Hello!

While working on the zed issue: https://github.com/zed-industries/zed/issues/51688

I found a fix to that issue, and also noticed a (very edge case) issue for macros with a type definition like `macro(ex)::Expr` was not getting the right syntax highlights.

Current behavior for the outline bug:

<img width="960" height="770" alt="before_long_funcs" src="https://github.com/user-attachments/assets/05956667-3557-42bd-8200-45b9ad9e76d2" />

Current behavior for the typed macro thing:

<img width="593" height="259" alt="before_macros" src="https://github.com/user-attachments/assets/951f50c1-c810-45ec-9ec3-1fe0f994c198" />

Combined shot of the fixes applied:

<img width="986" height="938" alt="after all changes applied" src="https://github.com/user-attachments/assets/25b3b8f3-9935-4ea3-8444-0fe0169545c8" />


I also tested things out in some of my julia projects, which aren't exactly huge production code bases, just some assignments, but nothing seemed obviously wrong.