### PR TITLE
Update to tree-sitter-julia v0.25.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Syntax tokens are called *captures* in tree-sitter jargon. The following table l
 | keyword.operator | no, falls back to keyword | `in`, `isa`, `where` |
 | keyword.repeat | no, falls back to keyword | `for`, `while` |
 | keyword.return | no, falls back to keyword | `return` |
-| keyword.type | no, falls back to keyword | primitive type definition |
+| keyword.type | no, falls back to keyword | struct or type definition |
 | label | yes | label name for `@label`, `@goto` |
 | number | yes |
 | number.float | no, falls back to number |

--- a/README.md
+++ b/README.md
@@ -168,17 +168,19 @@ You can change the foreground color and text attributes of syntax tokens in your
 
 ```json
 {
-  "experimental.theme_overrides": {
-    "syntax": {
-      "comment.doc": {
-        "font_style": "italic"
+  "theme_overrides": {
+    "One Dark": {
+      "syntax": {
+        "comment.doc": {
+          "font_style": "italic",
+        },
+        "function.definition": {
+          "color": "#0000AA",
+          "font_weight": 700,
+        },
       },
-      "function.definition": {
-        "color": "#0000AA",
-        "font_weight": 700
-      }
-    }
-  }
+    },
+  },
 }
 ```
 
@@ -191,6 +193,7 @@ Syntax tokens are called *captures* in tree-sitter jargon. The following table l
 | boolean | yes |
 | comment | yes | line or block comment |
 | comment.doc | yes | docstring |
+| constant | yes | 
 | constant.builtin | no, falls back to constant | core julia built-in |
 | function.builtin | no, falls back to function | core julia built-in |
 | function.call | no, falls back to function | name of the called function |
@@ -205,6 +208,8 @@ Syntax tokens are called *captures* in tree-sitter jargon. The following table l
 | keyword.operator | no, falls back to keyword | `in`, `isa`, `where` |
 | keyword.repeat | no, falls back to keyword | `for`, `while` |
 | keyword.return | no, falls back to keyword | `return` |
+| keyword.type | no, falls back to keyword | primitive type definition |
+| label | yes | label name for `@label`, `@goto` |
 | number | yes |
 | number.float | no, falls back to number |
 | operator | yes |

--- a/extension.toml
+++ b/extension.toml
@@ -1,14 +1,14 @@
 id = "julia"
 name = "Julia"
 description = "Julia support."
-version = "0.1.9"
+version = "0.1.10"
 schema_version = 1
 authors = ["Paul Berg <paul@plutojl.org>"]
 repository = "https://github.com/JuliaEditorSupport/zed-julia"
 
 [grammars.julia]
 repository = "https://github.com/tree-sitter/tree-sitter-julia"
-commit = "18b739c1563c83fc816170a4241adfa4b69e5c47"
+commit = "e0f9dcd180fdcfcfa8d79a3531e11d99e79321d3"
 
 [language_servers.julia]
 languages = ["Julia"]

--- a/languages/julia/highlights.scm
+++ b/languages/julia/highlights.scm
@@ -235,7 +235,7 @@
 ; Zed - added: Module name as type
 (module_definition
   ["module" "baremodule"]
-  (identifier) @type)
+  name: (identifier) @type)
 
 ; Zed - added: @goto/@label target labels
 ((macrocall_expression
@@ -333,7 +333,7 @@
 
 ; Zed - added: Match the dot in the @. macro
 (macro_identifier
-  "@"
+  "@" @function.macro
   (operator "." @function.macro))
 
 ; Zed - added: Function definitions
@@ -455,28 +455,30 @@
 
 ; (3) docstrings preceding documentable elements at the top of a module:
 (module_definition
-  (string_literal) @comment.doc
-  .
-  [
-    (assignment)
-    (const_statement)
-    (global_statement)
-    (abstract_definition)
-    (function_definition)
-    (macro_definition)
-    (module_definition)
-    (struct_definition)
-    (macrocall_expression) ; Covers things like @kwdef struct X ... end
-    (identifier)
-    (open_tuple
-      (identifier))
-  ])
+  (block
+    (string_literal) @comment.doc
+    .
+    [
+      (assignment)
+      (const_statement)
+      (global_statement)
+      (abstract_definition)
+      (function_definition)
+      (macro_definition)
+      (module_definition)
+      (struct_definition)
+      (macrocall_expression) ; Covers things like @kwdef struct X ... end
+      (identifier)
+      (open_tuple
+        (identifier))
+    ]))
 
 ; (4) struct field docstrings:
 (struct_definition
-  (string_literal) @comment.doc
-  .
-  [(identifier) (typed_expression)])
+  (block
+    (string_literal) @comment.doc
+    .
+    [(identifier) (typed_expression)]))
 
 [
   (line_comment)

--- a/languages/julia/highlights.scm
+++ b/languages/julia/highlights.scm
@@ -266,7 +266,7 @@
     "mutable"
     "struct"
     "end"
-  ] @keyword) ; Zed - changed `@keyword.type` to `@keyword`
+  ] @keyword.type)
 
 (abstract_definition
   [
@@ -423,7 +423,7 @@
 (prefixed_command_literal
   prefix: (identifier) @function.macro) @string.special
 
-; Zed - modified queries for docstrings (3 queries):
+; Zed - modified queries for docstrings (4 queries):
 
 ; (1) doc macro docstrings:
 ; @doc "..." x

--- a/languages/julia/injections.scm
+++ b/languages/julia/injections.scm
@@ -30,29 +30,31 @@
 
 ; docstrings preceding documentable elements at the top of a module:
 ((module_definition
-  (string_literal) @injection.content
-  .
-  [
-    (assignment)
-    (const_statement)
-    (global_statement)
-    (abstract_definition)
-    (function_definition)
-    (macro_definition)
-    (module_definition)
-    (struct_definition)
-    (macrocall_expression) ; Covers things like @kwdef struct X ... end
-    (identifier)
-    (open_tuple
-      (identifier))
-  ])
+  (block
+    (string_literal) @injection.content
+    .
+    [
+      (assignment)
+      (const_statement)
+      (global_statement)
+      (abstract_definition)
+      (function_definition)
+      (macro_definition)
+      (module_definition)
+      (struct_definition)
+      (macrocall_expression) ; Covers things like @kwdef struct X ... end
+      (identifier)
+      (open_tuple
+        (identifier))
+    ]))
   (#set! injection.language "markdown-inline"))
 
 ; struct field docstrings:
 ((struct_definition
-  (string_literal) @injection.content
-  .
-  [(identifier) (typed_expression)])
+  (block
+    (string_literal) @injection.content
+    .
+    [(identifier) (typed_expression)]))
   (#set! injection.language "markdown-inline"))
 
 ; HTML Language Injection

--- a/syntax-test-cases/edge-cases.jl
+++ b/syntax-test-cases/edge-cases.jl
@@ -17,7 +17,7 @@ end
 'w'
 
 # String interpolation
-# (highlight `$` and the outer parentheses as @punctuation.special)
+# (highlight `$` as @punctuation.special)
 "$(sqrt(2))"
 
 # Macro calls


### PR DESCRIPTION
Update to tree-sitter-julia v0.25.0.

BREAKING: The new grammar drops support for emojis as identifiers. This means that variable or function *names* etc. cannot contain emojis anymore. Of course, any values can still contain anything. 

There haven't been any complains upstream (nor in neovim) that variables can't be named ☠️ or 🧨 since this update came out five months ago so, we should be safe to follow their lead.

The new grammar is significantly smaller and more performant. It uses the newer tree-sitter ABI v14.

The new grammar exports a `(block)` node that should simplify future queries.