### PR TITLE
highlights: Tag struct field declarations as `@variable.member`

### DIFF
--- a/languages/julia/highlights.scm
+++ b/languages/julia/highlights.scm
@@ -268,6 +268,55 @@
     "end"
   ] @keyword.type)
 
+; Zed - added: struct field declarations
+; Covers `x`, `x::T`, and (for `@kwdef`) `x = v`, `x::T = v`.
+(struct_definition
+  (block
+    (identifier) @variable.member))
+
+(struct_definition
+  (block
+    (typed_expression
+      . (identifier) @variable.member)))
+
+(struct_definition
+  (block
+    (assignment
+      . (identifier) @variable.member)))
+
+(struct_definition
+  (block
+    (assignment
+      . (typed_expression
+          . (identifier) @variable.member))))
+
+; Zed - added: const-qualified mutable struct fields (Julia 1.8+).
+; Same shapes as above wrapped in `const_statement`; the `= v`
+; forms only appear inside `Base.@kwdef`-wrapped structs.
+(struct_definition
+  (block
+    (const_statement
+      (identifier) @variable.member)))
+
+(struct_definition
+  (block
+    (const_statement
+      (typed_expression
+        . (identifier) @variable.member))))
+
+(struct_definition
+  (block
+    (const_statement
+      (assignment
+        . (identifier) @variable.member))))
+
+(struct_definition
+  (block
+    (const_statement
+      (assignment
+        . (typed_expression
+            . (identifier) @variable.member)))))
+
 (abstract_definition
   [
     "abstract"


### PR DESCRIPTION
Until now, identifiers appearing as struct field declarations (e.g. `x` and `y` in `struct S; x; y::Int; end`) fell through to the generic `(identifier) @variable` rule and were styled the same as ordinary variable references.

This gives field declarations the same `@variable.member` capture that `x.y.z` field accesses already get, so themes can differentiate "struct member" from regular variables uniformly across declaration and access sites.

Four query variants cover:
- plain field (`x`)
- typed field (`x::T`)
- `@kwdef` default (`x = v`)
- `@kwdef` typed default (`x::T = v`)

Inner constructors written either as `Foo(x) = new(x)` or `function Foo(x) ... end` are not matched, since their LHS is a `call_expression` rather than `identifier` / `typed_expression`.

Example:
| Before | <img width="998" height="452" alt="Screenshot 2026-05-09 at 13 00 24" src="https://github.com/user-attachments/assets/67db8ea0-82d1-41d3-b171-c725337ba8b5" /> |
| ------ | ----- |
| After  | <img width="998" height="452" alt="Screenshot 2026-05-09 at 12 59 08" src="https://github.com/user-attachments/assets/daf07a00-311c-4d3a-941c-5d0d1d1a83eb" /> |
