### PR TITLE
Feat/improve block recognition

### DIFF
--- a/languages/julia/config.toml
+++ b/languages/julia/config.toml
@@ -62,5 +62,5 @@ decrease_indent_patterns = [
     { pattern = "^\\s*else\\b.*", valid_after = ["if", "elseif", "try", "catch"] },
     { pattern = "^\\s*catch\\b.*", valid_after = ["try"] },
     { pattern = "^\\s*finally\\b.*", valid_after = ["try", "catch"] },
-    { pattern = "^\\s*end\\b.*", valid_after = ["function", "if", "for", "while", "begin", "let", "do", "try", "struct", "macro", "quote"] }
+    { pattern = "^\\s*end\\b.*", valid_after = ["function", "if", "for", "while", "begin", "let", "do", "try", "struct", "macro", "quote", "module"] }
 ]

--- a/languages/julia/indents.scm
+++ b/languages/julia/indents.scm
@@ -1,6 +1,9 @@
 ; `@start.xxx` marks where these clauses start for `valid_after` matching in config.toml
 
 [
+  (module_definition
+    ["module" "baremodule"] @start.module
+    "end" @end)
   (struct_definition
     "struct" @start.struct
     "end" @end)

--- a/languages/julia/outline.scm
+++ b/languages/julia/outline.scm
@@ -14,10 +14,6 @@
       [(identifier) (import_path)] @name)
   ]) @item
 
-(module_definition
-  ["module" "baremodule"] @context
-  name: (identifier) @name) @item
-
 (abstract_definition
   "abstract" @context
   "type" @context
@@ -115,3 +111,27 @@
   (identifier) @_call @context
   (argument_list) @name
   (#eq? @_call "include")) @item
+
+; --- Added: Block structures for selection and outline ---
+
+(compound_statement
+  "begin" @name) @item
+
+(if_statement
+  "if" @context
+  condition: (_) @name) @item
+
+(for_statement
+  "for" @context
+  (_) @name) @item
+
+(while_statement
+  "while" @context
+  condition: (_) @name) @item
+
+(let_statement
+  "let" @context
+  (_) @name) @item
+
+(try_statement
+  "try" @name) @item

--- a/syntax-test-cases/blocks.jl
+++ b/syntax-test-cases/blocks.jl
@@ -1,0 +1,71 @@
+# Test file for block recognition and indentation
+
+# 1. Module Indentation & Selection Test
+# Try "Select Enclosing Symbol" inside foo() -> then again -> then again.
+# You will see it eventually selects the entire MyModule.
+module MyModule
+using LinearAlgebra
+
+x = 1
+
+function foo(a)
+    println("Processing: ", a)
+    begin
+        # A nested block
+        result = a * 2
+        return result
+    end
+end
+
+function bar(b)
+    if b > 0
+        return sqrt(b)
+    else
+        return 0
+    end
+end
+end
+# 2. Block Recognition Test (Outline / Selection)
+# These should now be recognized as selectable symbols in Zed
+
+begin
+    a = 1
+    b = 2
+    c = a + b
+end
+
+# x = 10
+x = -10
+if x > 0
+    println("positive")
+else
+    println("non-positive")
+end
+
+for i in 1:10
+    println(i)
+end
+
+condition = true
+i = 0
+while condition
+    println(i)
+    if i > 3
+        condition = false
+    end
+    i += 1
+end
+
+let x = 1, y = 2
+    print(x + y)
+end
+
+
+try
+    result = sqrt(-1)  # Should throw a DomainError
+    println("Result: $result")
+catch e
+    @error "Caught an error" exception = e
+finally
+    println("Cleanup complete")
+end


### PR DESCRIPTION
I just think it is useful to support the various code blocks (i.e., begin/end, let/end, if/else/end, etc...) in ZED.

This PR improves how Zed recognizes Julia code blocks (like `begin`, `if`, `for`), making features like `SelectEnclosingSymbol` much more useful for REPL-based workflows.

It also fixes an issue where `module` blocks were not indenting correctly.

## Changes
* **Symbol Recognition**: Added control flow blocks (`begin`, `if`, `for`, `while`, `let`, `try`) to `outline.scm`. This allows users to easily select and send these blocks to the REPL using `editor::SelectEnclosingSymbol`.
* **Module Selection**: Removed `module` from `outline.scm`. Since modules often wrap the entire file, this prevents users from accidentally selecting and sending huge chunks of code to the REPL when expanding their selection.
* **Indentation Fix**: Added `module_definition` to `indents.scm` and updated `config.toml` to ensure code inside `module` blocks indents and outdents correctly.
* **Tests**: Added `syntax-test-cases/blocks.jl` to verify the new behaviors.

## Side Effects
Note that adding control flow blocks to `outline.scm` introduces two side effects:
1. **Outline Panel**: The Outline view (`cmd-shift-o`) will now include these control flow blocks, which makes the list more detailed but potentially longer and "noisier" in large files.
2. **Sticky Scroll**: Sticky scroll will now "stick" on `if` statements and `for` loops, showing deeper nesting levels (e.g., `function` > `for` > `if`). While this takes up slightly more screen space, it provides better context.

I think these are acceptable trade-offs for the massive improvement in the REPL workflow, as selecting and evaluating individual blocks is a core part of Julia development.

## Screenshots / Screencasts
<img width="581" height="899" alt="image" src="https://github.com/user-attachments/assets/de7b873b-716a-43aa-b1cd-91fc5ab98c22" />
